### PR TITLE
fix: CI lint errors + ARM64 Lambda build

### DIFF
--- a/.github/workflows/deploy_paralegal.yml
+++ b/.github/workflows/deploy_paralegal.yml
@@ -57,6 +57,14 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      # Setup Docker Buildx for multi-platform builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Setup QEMU for ARM64 emulation
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # 1. Backend 배포 (ECR Push + Lambda Update)
       - name: Build & Push Backend
         if: github.ref == 'refs/heads/main'
@@ -65,11 +73,14 @@ jobs:
           ECR_REPOSITORY: leh-backend
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          # Lambda용 Dockerfile로 빌드
-          docker build -f ./backend/Dockerfile.lambda -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./backend
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          # Lambda용 Dockerfile로 ARM64 이미지 빌드 (Lambda가 arm64로 설정됨)
+          docker buildx build \
+            --platform linux/arm64 \
+            -f ./backend/Dockerfile.lambda \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            --push \
+            ./backend
 
           # Lambda 함수 코드를 새 이미지로 교체
           aws lambda update-function-code \
@@ -77,20 +88,23 @@ jobs:
             --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       # 2. AI Worker 배포 (ECR Push + Lambda Update)
+      # Note: Skipped until ai_worker/Dockerfile is created
       - name: Build & Push AI Worker
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && false
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: leh-ai-worker
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          # Docker 빌드 및 푸시
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./ai_worker
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          # Docker 빌드 및 푸시 (ARM64)
+          docker buildx build \
+            --platform linux/arm64 \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            --push \
+            ./ai_worker
 
-          # [핵심] Lambda 함수 코드를 새 이미지로 교체
+          # Lambda 함수 코드를 새 이미지로 교체
           aws lambda update-function-code \
             --function-name leh-ai-worker \
             --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/backend/alembic/versions/6d1f9eb6cc85_initial_migration.py
+++ b/backend/alembic/versions/6d1f9eb6cc85_initial_migration.py
@@ -7,8 +7,8 @@ Create Date: 2025-12-01 18:08:00.818197
 """
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
+from alembic import op  # noqa: F401
+import sqlalchemy as sa  # noqa: F401
 
 
 # revision identifiers, used by Alembic.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,6 @@ from fastapi.testclient import TestClient
 from unittest.mock import Mock, patch, MagicMock
 import os
 import uuid
-from pathlib import Path
 
 
 def pytest_configure(config):


### PR DESCRIPTION
## Summary
- Fix Ruff lint errors in backend (the only CI failure)
- Add ARM64 build support for Lambda deployment

## Changes

### Backend Lint Fixes
- `alembic/versions/6d1f9eb6cc85_initial_migration.py`: Add `# noqa: F401` for required imports
- `tests/conftest.py`: Remove unused `Path` import

### Deploy Workflow
- Add Docker Buildx and QEMU for cross-platform builds
- Build with `--platform linux/arm64` to match Lambda architecture
- Disable AI Worker build until Dockerfile is created

## Test Plan
- [ ] CI passes (lint + tests)
- [ ] Lambda deployment works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **인프라 개선**
  * 다중 플랫폼 빌드 지원으로 배포 프로세스 최적화
  * Lambda 백엔드 이미지 빌드 워크플로우 업그레이드

* **Chores**
  * 테스트 및 마이그레이션 파일의 불필요한 코드 정리
  * 린트 경고 억제 주석 추가

**참고:** AI Worker 기능은 일시적으로 비활성화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->