### PR TITLE
feat: add Makefile and Quick Start guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,124 @@
+# LEH Development Makefile
+# Quick setup and development commands
+
+.PHONY: setup setup-backend setup-ai-worker setup-frontend
+.PHONY: dev dev-backend dev-frontend
+.PHONY: test test-backend test-ai-worker test-frontend
+.PHONY: lint clean help
+
+# =============================================================================
+# SETUP COMMANDS
+# =============================================================================
+
+## Install all dependencies for all services
+setup: setup-backend setup-ai-worker setup-frontend
+	@echo "All services set up successfully!"
+
+## Setup Backend (FastAPI)
+setup-backend:
+	@echo "Setting up Backend..."
+	cd backend && python -m venv .venv
+	cd backend && . .venv/bin/activate && pip install -r requirements.txt
+	@echo "Backend setup complete!"
+
+## Setup AI Worker (Lambda)
+setup-ai-worker:
+	@echo "Setting up AI Worker..."
+	cd ai_worker && python -m venv .venv
+	cd ai_worker && . .venv/bin/activate && pip install -r requirements.txt
+	@echo "AI Worker setup complete!"
+
+## Setup Frontend (Next.js)
+setup-frontend:
+	@echo "Setting up Frontend..."
+	cd frontend && npm install
+	@echo "Frontend setup complete!"
+
+# =============================================================================
+# DEVELOPMENT COMMANDS
+# =============================================================================
+
+## Run all services (requires multiple terminals)
+dev:
+	@echo "Run these commands in separate terminals:"
+	@echo "  Terminal 1: make dev-backend"
+	@echo "  Terminal 2: make dev-frontend"
+
+## Run Backend development server
+dev-backend:
+	cd backend && . .venv/bin/activate && uvicorn app.main:app --reload
+
+## Run Frontend development server
+dev-frontend:
+	cd frontend && npm run dev
+
+# =============================================================================
+# TEST COMMANDS
+# =============================================================================
+
+## Run all tests
+test: test-backend test-ai-worker test-frontend
+	@echo "All tests completed!"
+
+## Run Backend tests
+test-backend:
+	cd backend && . .venv/bin/activate && pytest
+
+## Run AI Worker tests
+test-ai-worker:
+	cd ai_worker && . .venv/bin/activate && pytest
+
+## Run Frontend tests
+test-frontend:
+	cd frontend && npm test
+
+# =============================================================================
+# LINT COMMANDS
+# =============================================================================
+
+## Run linters on all services
+lint:
+	cd backend && . .venv/bin/activate && ruff check app/ tests/
+	cd ai_worker && . .venv/bin/activate && ruff check src/ tests/
+	cd frontend && npm run lint
+
+# =============================================================================
+# CLEANUP COMMANDS
+# =============================================================================
+
+## Clean up virtual environments and node_modules
+clean:
+	rm -rf backend/.venv
+	rm -rf ai_worker/.venv
+	rm -rf frontend/node_modules
+	rm -rf backend/test.db
+	@echo "Cleanup complete!"
+
+# =============================================================================
+# HELP
+# =============================================================================
+
+## Show this help message
+help:
+	@echo "LEH Development Commands"
+	@echo "========================"
+	@echo ""
+	@echo "Setup:"
+	@echo "  make setup           - Install all dependencies"
+	@echo "  make setup-backend   - Setup Backend only"
+	@echo "  make setup-ai-worker - Setup AI Worker only"
+	@echo "  make setup-frontend  - Setup Frontend only"
+	@echo ""
+	@echo "Development:"
+	@echo "  make dev-backend     - Run Backend server"
+	@echo "  make dev-frontend    - Run Frontend server"
+	@echo ""
+	@echo "Testing:"
+	@echo "  make test            - Run all tests"
+	@echo "  make test-backend    - Run Backend tests"
+	@echo "  make test-ai-worker  - Run AI Worker tests"
+	@echo "  make test-frontend   - Run Frontend tests"
+	@echo ""
+	@echo "Other:"
+	@echo "  make lint            - Run linters"
+	@echo "  make clean           - Remove venvs and node_modules"

--- a/README.md
+++ b/README.md
@@ -58,21 +58,35 @@ LEH는 **이혼 사건 전용 AI 파라리걸 & 증거 허브** 플랫폼입니�
 
 ## 4. 시작하기 (Getting Started)
 
-### 4.1 사전 요구사항
+### 4.1 Quick Start (원클릭 설정)
+
+```bash
+# 1. 레포 클론
+git clone https://github.com/KernelAcademy-AICamp/ai-camp-2nd-llm-agent-service-project-2nd.git
+cd ai-camp-2nd-llm-agent-service-project-2nd
+
+# 2. 환경 변수 설정
+cp .env.example .env
+# .env 파일 편집하여 필수 값 입력
+
+# 3. 전체 설정 (Makefile 사용)
+make setup
+
+# 4. 개발 서버 실행 (각각 별도 터미널)
+make dev-backend   # http://localhost:8000
+make dev-frontend  # http://localhost:3000
+```
+
+> **Makefile 명령어 전체 보기**: `make help`
+
+### 4.2 사전 요구사항
 
 - Python 3.11+
 - Node.js 18+
 - AWS 계정 + IAM (S3, DynamoDB 등)
 - OpenAI API 키
 
-### 4.2 레포 클론
-
-```bash
-git clone https://github.com/KernelAcademy-AICamp/ai-camp-2nd-llm-agent-service-project-2nd.git
-cd ai-camp-2nd-llm-agent-service-project-2nd
-```
-
-### 4.3 환경 변수 설정
+### 4.4 환경 변수 설정
 
 LEH는 **통합 `.env` 파일**을 사용합니다:
 
@@ -89,7 +103,7 @@ cp .env.example .env
 
 > `.env`는 절대 Git에 커밋하지 않습니다.
 
-### 4.4 백엔드 실행 (FastAPI)
+### 4.5 백엔드 실행 (FastAPI)
 
 ```bash
 cd backend
@@ -100,7 +114,7 @@ uvicorn app.main:app --reload
 # http://localhost:8000
 ```
 
-### 4.5 프론트엔드 실행 (Next.js)
+### 4.6 프론트엔드 실행 (Next.js)
 
 ```bash
 cd frontend
@@ -109,7 +123,7 @@ npm run dev
 # http://localhost:3000
 ```
 
-### 4.6 AI Worker 실행 (로컬 테스트)
+### 4.7 AI Worker 실행 (로컬 테스트)
 
 ```bash
 cd ai_worker
@@ -155,6 +169,7 @@ python -m handler
 │   └── business/         # 비즈니스 문서
 │
 ├── CLAUDE.md             # AI 에이전트 규칙
+├── Makefile              # 개발 자동화 스크립트
 └── README.md             # 이 파일
 ```
 


### PR DESCRIPTION
## Summary
- Add Makefile with setup, dev, test, lint, and clean commands
- Add Quick Start section (4.1) to README for one-click setup
- Update section numbering in README (4.2-4.7)
- Add Makefile to repository structure diagram

## Changes
- `Makefile`: New file with development automation commands
  - `make setup` - Install all dependencies
  - `make dev-backend` / `make dev-frontend` - Run dev servers
  - `make test` - Run all tests
  - `make lint` - Run linters
  - `make clean` - Clean up venvs and node_modules
- `README.md`: Add Quick Start section with `make` commands

## Test Plan
- [ ] Run `make setup` on fresh clone
- [ ] Verify `make dev-backend` starts FastAPI
- [ ] Verify `make dev-frontend` starts Next.js
- [ ] Run `make test` to verify all tests pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)