### PR TITLE
feat(T155): Add summary card button to case detail page

### DIFF
--- a/frontend/src/app/lawyer/cases/[id]/LawyerCaseDetailClient.tsx
+++ b/frontend/src/app/lawyer/cases/[id]/LawyerCaseDetailClient.tsx
@@ -11,6 +11,8 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { apiClient } from '@/lib/api/client';
+import ExplainerCard from '@/components/cases/ExplainerCard';
+import ShareSummaryModal from '@/components/cases/ShareSummaryModal';
 
 interface CaseDetail {
   id: string;
@@ -76,6 +78,8 @@ export default function LawyerCaseDetailClient({ id }: LawyerCaseDetailClientPro
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'evidence' | 'timeline' | 'members'>('evidence');
+  const [showSummaryCard, setShowSummaryCard] = useState(false);
+  const [showShareModal, setShowShareModal] = useState(false);
 
   useEffect(() => {
     const fetchCaseDetail = async () => {
@@ -192,6 +196,16 @@ export default function LawyerCaseDetailClient({ id }: LawyerCaseDetailClientPro
               className="px-4 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50"
             >
               수정
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowSummaryCard(true)}
+              className="px-4 py-2 border border-purple-300 text-purple-700 rounded-lg text-sm hover:bg-purple-50 flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              요약 카드 생성
             </button>
             <button
               type="button"
@@ -377,6 +391,25 @@ export default function LawyerCaseDetailClient({ id }: LawyerCaseDetailClientPro
           </div>
         )}
       </div>
+
+      {/* Summary Card Modal */}
+      <ExplainerCard
+        caseId={caseId}
+        isOpen={showSummaryCard}
+        onClose={() => setShowSummaryCard(false)}
+        onShare={() => {
+          setShowSummaryCard(false);
+          setShowShareModal(true);
+        }}
+      />
+
+      {/* Share Summary Modal */}
+      <ShareSummaryModal
+        caseId={caseId}
+        caseTitle={caseDetail.title}
+        isOpen={showShareModal}
+        onClose={() => setShowShareModal(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add '요약 카드 생성' button to lawyer case detail header
- Integrate ExplainerCard and ShareSummaryModal components

## Test plan
- [ ] Verify button displays on case detail page
- [ ] Click button opens ExplainerCard modal
- [ ] Share button in modal opens ShareSummaryModal