### PR TITLE
feat(ai_worker): enable AI Worker deployment in CI/CD

### DIFF
--- a/.github/workflows/deploy_paralegal.yml
+++ b/.github/workflows/deploy_paralegal.yml
@@ -90,17 +90,20 @@ jobs:
             --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       # 2. AI Worker 배포 (ECR Push + Lambda Update)
-      # Note: Skipped until ai_worker/Dockerfile is created
       - name: Build & Push AI Worker
-        if: github.ref == 'refs/heads/main' && false
+        if: github.ref == 'refs/heads/main'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: leh-ai-worker
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          # Docker 빌드 및 푸시 (ARM64)
+          # Lambda용 Dockerfile로 x86_64 이미지 빌드 (Lambda가 x86_64로 설정됨)
+          # --provenance=false --sbom=false: Lambda에서 지원하지 않는 OCI manifest 비활성화
           docker buildx build \
-            --platform linux/arm64 \
+            --platform linux/amd64 \
+            --provenance=false \
+            --sbom=false \
+            -f ./ai_worker/Dockerfile.lambda \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
             --push \

--- a/ai_worker/handler.py
+++ b/ai_worker/handler.py
@@ -586,8 +586,23 @@ def handle(event, context):
     """
     AWS Lambda Entrypoint.
     S3 이벤트를 수신하여 파일 정보를 파싱하고 AI 파이프라인을 시작합니다.
+
+    Supported event types:
+    - S3 ObjectCreated events: Process uploaded files
+    - Health check: {"action": "health"} → Returns service status
     """
     logger.info(f"Received event: {json.dumps(event)}")
+
+    # Health check endpoint (for monitoring and deployment verification)
+    if event.get("action") == "health":
+        return {
+            "statusCode": 200,
+            "body": json.dumps({
+                "status": "healthy",
+                "service": "leh-ai-worker",
+                "version": os.getenv("AWS_LAMBDA_FUNCTION_VERSION", "unknown")
+            })
+        }
 
     # S3 이벤트가 아닌 경우(테스트 등) 방어 로직
     if "Records" not in event:


### PR DESCRIPTION
## Summary
- deploy_paralegal.yml에서 AI Worker 배포 활성화
- handler.py에 health check 엔드포인트 추가

## Changes
| 파일 | 변경 |
|------|------|
| `.github/workflows/deploy_paralegal.yml` | `&& false` 제거, Dockerfile 경로 수정, Lambda 호환 옵션 추가 |
| `ai_worker/handler.py` | `{"action": "health"}` 이벤트로 health check 지원 |

## Test plan
- [ ] main 브랜치 push 시 AI Worker 빌드/배포 동작 확인
- [ ] Lambda에서 health check 이벤트 테스트: `{"action": "health"}`

## Related Issues
Closes #181, #182, #183