### PR TITLE
feat(ai_worker): add CloudWatch observability (T056, T057)

### DIFF
--- a/ai_worker/handler.py
+++ b/ai_worker/handler.py
@@ -62,7 +62,16 @@ from src.utils.cost_guard import (
     get_file_type_from_extension
 )
 
-logger = logging.getLogger()
+# Configure structured JSON logging for Lambda/CloudWatch (T056)
+from src.utils.logging import setup_logging
+
+# Check if running in Lambda environment
+_is_lambda = os.getenv("AWS_LAMBDA_FUNCTION_NAME") is not None
+
+# Setup JSON logging for Lambda (CloudWatch compatible), console for local dev
+setup_logging(level="INFO", json_output=_is_lambda)
+
+logger = logging.getLogger("ai_worker")
 logger.setLevel(logging.INFO)
 logger.addFilter(SensitiveDataFilter())
 
@@ -586,8 +595,27 @@ def handle(event, context):
     """
     AWS Lambda Entrypoint.
     S3 이벤트를 수신하여 파일 정보를 파싱하고 AI 파이프라인을 시작합니다.
+
+    Supported event types:
+    - S3 ObjectCreated events: Process uploaded files
+    - Health check: {"action": "health"} → Returns service status
     """
+    # Import metrics (T057)
+    from src.utils.metrics import get_metrics_publisher, flush_metrics
+
     logger.info(f"Received event: {json.dumps(event)}")
+    metrics = get_metrics_publisher()
+
+    # Health check endpoint (for monitoring and deployment verification)
+    if event.get("action") == "health":
+        return {
+            "statusCode": 200,
+            "body": json.dumps({
+                "status": "healthy",
+                "service": "leh-ai-worker",
+                "version": os.getenv("AWS_LAMBDA_FUNCTION_VERSION", "unknown")
+            })
+        }
 
     # S3 이벤트가 아닌 경우(테스트 등) 방어 로직
     if "Records" not in event:
@@ -609,13 +637,24 @@ def handle(event, context):
             logger.info(f"Processing file: s3://{bucket_name}/{object_key}")
 
             # 2. 파일 처리 로직 실행 (Strategy Pattern 적용)
-            result = route_and_process(bucket_name, object_key)
+            with metrics.track_execution("FULL_PIPELINE"):
+                result = route_and_process(bucket_name, object_key)
+
+            # Record processed messages count (T057)
+            if result.get("status") == "processed":
+                chunks = result.get("chunks_indexed", 0)
+                metrics.record_processed_messages(chunks)
+
             results.append(result)
 
         except Exception as e:
             logger.error(f"Error processing record: {e}", exc_info=True)
+            metrics.record_error(type(e).__name__)
             # 실제 운영 시에는 여기서 DLQ로 보내거나 에러를 다시 raise 해야 함
             results.append({"error": str(e), "status": "failed"})
+
+    # Flush all metrics to CloudWatch (T057)
+    flush_metrics()
 
     return {
         "statusCode": 200,

--- a/ai_worker/src/utils/metrics.py
+++ b/ai_worker/src/utils/metrics.py
@@ -1,0 +1,271 @@
+"""
+CloudWatch Custom Metrics for AI Worker Lambda (T057)
+
+Provides:
+- Lambda execution time tracking
+- Memory usage tracking
+- Error rate tracking
+- Processing stage metrics
+
+Usage:
+    from src.utils.metrics import MetricsPublisher
+
+    metrics = MetricsPublisher()
+
+    # Track execution time
+    with metrics.track_execution():
+        process_file(...)
+
+    # Record custom metric
+    metrics.record_metric("ParsedMessages", 150, unit="Count")
+
+    # Record error
+    metrics.record_error("PARSE_ERROR")
+"""
+
+import os
+import time
+import logging
+from datetime import datetime, timezone
+from typing import Optional, Dict, Any, List
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger("ai_worker.metrics")
+
+# Metric namespace for CloudWatch
+METRIC_NAMESPACE = "LEH/AIWorker"
+
+
+@dataclass
+class MetricData:
+    """Single metric data point"""
+    name: str
+    value: float
+    unit: str = "None"
+    dimensions: Dict[str, str] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class MetricsPublisher:
+    """
+    CloudWatch Metrics Publisher for AI Worker.
+
+    Batches metrics and publishes to CloudWatch for monitoring.
+    """
+
+    # Valid CloudWatch units
+    VALID_UNITS = {
+        "Seconds", "Microseconds", "Milliseconds",
+        "Bytes", "Kilobytes", "Megabytes", "Gigabytes",
+        "Bits", "Kilobits", "Megabits", "Gigabits",
+        "Percent", "Count", "None"
+    }
+
+    def __init__(
+        self,
+        namespace: str = METRIC_NAMESPACE,
+        enabled: bool = True,
+        batch_size: int = 20
+    ):
+        """
+        Initialize metrics publisher.
+
+        Args:
+            namespace: CloudWatch metric namespace
+            enabled: Whether to actually publish metrics (disable for local dev)
+            batch_size: Number of metrics to batch before publishing
+        """
+        self.namespace = namespace
+        self.enabled = enabled and os.getenv("AWS_LAMBDA_FUNCTION_NAME") is not None
+        self.batch_size = batch_size
+        self._metrics_buffer: List[MetricData] = []
+        self._client = None
+
+        # Default dimensions (added to all metrics)
+        self._default_dimensions = {
+            "FunctionName": os.getenv("AWS_LAMBDA_FUNCTION_NAME", "local"),
+            "Environment": os.getenv("ENVIRONMENT", "dev"),
+        }
+
+    @property
+    def client(self):
+        """Lazy-load CloudWatch client"""
+        if self._client is None:
+            self._client = boto3.client("cloudwatch")
+        return self._client
+
+    def record_metric(
+        self,
+        name: str,
+        value: float,
+        unit: str = "None",
+        dimensions: Optional[Dict[str, str]] = None
+    ) -> None:
+        """
+        Record a metric value.
+
+        Args:
+            name: Metric name (e.g., "ExecutionTime", "ParsedMessages")
+            value: Metric value
+            unit: CloudWatch unit (Milliseconds, Count, Percent, etc.)
+            dimensions: Additional dimensions
+        """
+        if unit not in self.VALID_UNITS:
+            logger.warning(f"Invalid unit '{unit}', using 'None'")
+            unit = "None"
+
+        all_dimensions = {**self._default_dimensions}
+        if dimensions:
+            all_dimensions.update(dimensions)
+
+        metric = MetricData(
+            name=name,
+            value=value,
+            unit=unit,
+            dimensions=all_dimensions
+        )
+
+        self._metrics_buffer.append(metric)
+
+        # Auto-flush if buffer is full
+        if len(self._metrics_buffer) >= self.batch_size:
+            self.flush()
+
+    def record_execution_time(self, duration_ms: float, stage: Optional[str] = None) -> None:
+        """Record Lambda execution time"""
+        dimensions = {"Stage": stage} if stage else None
+        self.record_metric("ExecutionTime", duration_ms, "Milliseconds", dimensions)
+
+    def record_memory_usage(self, memory_mb: float) -> None:
+        """Record memory usage"""
+        self.record_metric("MemoryUsed", memory_mb, "Megabytes")
+
+    def record_error(self, error_type: str) -> None:
+        """Record an error occurrence"""
+        self.record_metric("ErrorCount", 1, "Count", {"ErrorType": error_type})
+
+    def record_success(self) -> None:
+        """Record successful processing"""
+        self.record_metric("SuccessCount", 1, "Count")
+
+    def record_processed_messages(self, count: int) -> None:
+        """Record number of messages processed"""
+        self.record_metric("ProcessedMessages", count, "Count")
+
+    def record_embedding_count(self, count: int, is_fallback: bool = False) -> None:
+        """Record embeddings generated"""
+        metric_name = "FallbackEmbeddings" if is_fallback else "Embeddings"
+        self.record_metric(metric_name, count, "Count")
+
+    @contextmanager
+    def track_execution(self, stage: Optional[str] = None):
+        """
+        Context manager to track execution time.
+
+        Usage:
+            with metrics.track_execution("PARSE"):
+                result = parser.parse(file)
+        """
+        start_time = time.time()
+        try:
+            yield
+            self.record_success()
+        except Exception as e:
+            error_type = type(e).__name__
+            self.record_error(error_type)
+            raise
+        finally:
+            duration_ms = (time.time() - start_time) * 1000
+            self.record_execution_time(duration_ms, stage)
+
+    def flush(self) -> None:
+        """Publish all buffered metrics to CloudWatch"""
+        if not self._metrics_buffer:
+            return
+
+        if not self.enabled:
+            logger.debug(f"Metrics disabled, skipping {len(self._metrics_buffer)} metrics")
+            self._metrics_buffer.clear()
+            return
+
+        try:
+            # Convert to CloudWatch format
+            metric_data = []
+            for m in self._metrics_buffer:
+                data = {
+                    "MetricName": m.name,
+                    "Value": m.value,
+                    "Unit": m.unit,
+                    "Timestamp": m.timestamp,
+                }
+                if m.dimensions:
+                    data["Dimensions"] = [
+                        {"Name": k, "Value": v}
+                        for k, v in m.dimensions.items()
+                    ]
+                metric_data.append(data)
+
+            # Publish in batches of 20 (CloudWatch limit)
+            for i in range(0, len(metric_data), 20):
+                batch = metric_data[i:i + 20]
+                self.client.put_metric_data(
+                    Namespace=self.namespace,
+                    MetricData=batch
+                )
+                logger.debug(f"Published {len(batch)} metrics to CloudWatch")
+
+            self._metrics_buffer.clear()
+
+        except ClientError as e:
+            logger.error(f"Failed to publish metrics: {e}")
+            # Don't raise - metrics should not break the main flow
+            self._metrics_buffer.clear()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.flush()
+        return False
+
+
+# Singleton instance for convenience
+_default_publisher: Optional[MetricsPublisher] = None
+
+
+def get_metrics_publisher() -> MetricsPublisher:
+    """Get the default metrics publisher singleton"""
+    global _default_publisher
+    if _default_publisher is None:
+        _default_publisher = MetricsPublisher()
+    return _default_publisher
+
+
+def record_metric(name: str, value: float, unit: str = "None", **dimensions) -> None:
+    """Convenience function to record a metric"""
+    get_metrics_publisher().record_metric(name, value, unit, dimensions or None)
+
+
+def record_error(error_type: str) -> None:
+    """Convenience function to record an error"""
+    get_metrics_publisher().record_error(error_type)
+
+
+def flush_metrics() -> None:
+    """Convenience function to flush all metrics"""
+    get_metrics_publisher().flush()
+
+
+__all__ = [
+    "MetricsPublisher",
+    "MetricData",
+    "METRIC_NAMESPACE",
+    "get_metrics_publisher",
+    "record_metric",
+    "record_error",
+    "flush_metrics",
+]


### PR DESCRIPTION
## Summary
- T056: Lambda 구조화 JSON 로깅 활성화
- T057: CloudWatch 커스텀 메트릭 추가

## Changes
| 파일 | 변경 |
|------|------|
| `ai_worker/handler.py` | JSON 로깅 설정, 메트릭 통합, health check 추가 |
| `ai_worker/src/utils/metrics.py` | **NEW** - CloudWatch 메트릭 퍼블리셔 |

## Features

### T056: JSON Logging
- Lambda 환경에서 자동 JSON 포맷 출력
- CloudWatch Logs Insights 쿼리 가능
- 로컬 개발 시 콘솔 포맷 유지

### T057: Custom Metrics
- `LEH/AIWorker` 네임스페이스
- 메트릭: ExecutionTime, ErrorCount, SuccessCount, ProcessedMessages
- 자동 배치 및 flush

## Test plan
- [ ] Lambda 배포 후 CloudWatch Logs에서 JSON 로그 확인
- [ ] CloudWatch Metrics 콘솔에서 `LEH/AIWorker` 네임스페이스 확인
- [ ] Health check 테스트: `{"action": "health"}`

## Related Issues
Closes #204, #205