### PR TITLE
fix(ai_worker): Add missing get_evidence method to MetadataStore

### DIFF
--- a/ai_worker/src/storage/metadata_store.py
+++ b/ai_worker/src/storage/metadata_store.py
@@ -531,6 +531,32 @@ class MetadataStore:
             logger.error(f"DynamoDB update_item error for {evidence_id}: {e}")
             raise
 
+    def get_evidence(self, evidence_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Evidence ID로 레코드 조회 (raw dict 반환)
+
+        Args:
+            evidence_id: Evidence ID
+
+        Returns:
+            Dict with evidence data or None if not found
+        """
+        try:
+            response = self.client.get_item(
+                TableName=self.table_name,
+                Key={'evidence_id': {'S': evidence_id}}
+            )
+
+            item = response.get('Item')
+            if not item:
+                return None
+
+            return self._deserialize_item(item)
+
+        except ClientError as e:
+            logger.error(f"DynamoDB get_item error for evidence {evidence_id}: {e}")
+            return None
+
     def get_file(self, file_id: str) -> Optional[EvidenceFile]:
         """
         파일 ID로 조회


### PR DESCRIPTION
## Summary
- AI Worker에서 증거 업로드 시 `'MetadataStore' object has no attribute 'get_evidence'` 에러로 처리가 실패하는 버그 수정
- `MetadataStore` 클래스에 누락된 `get_evidence` 메서드 추가

## Problem
- `handler.py:230`에서 `metadata_store.get_evidence()`를 호출하지만 해당 메서드가 정의되지 않음
- 결과: 모든 증거 업로드가 `processing` 상태에서 멈춤

## Test plan
- [ ] Lambda 배포 후 증거 업로드 테스트
- [ ] DynamoDB에서 status가 `completed`로 변경되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)