### PR TITLE
feat(auth): Automatic token refresh on 401 responses (#311)

### DIFF
--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -134,3 +134,14 @@ export async function getCurrentUser(): Promise<ApiResponse<UserInfo>> {
     method: 'GET',
   });
 }
+
+/**
+ * Refresh access token using refresh token from HTTP-only cookie
+ * Backend /auth/refresh endpoint reads refresh_token cookie and issues new access_token
+ * (#311: Auto token refresh implementation)
+ */
+export async function refreshAccessToken(): Promise<ApiResponse<LoginResponse>> {
+  return apiRequest<LoginResponse>('/auth/refresh', {
+    method: 'POST',
+  });
+}


### PR DESCRIPTION
## Summary
- Access token 만료 시 자동으로 refresh token을 사용해 새 토큰을 발급받고 원래 요청을 재시도
- 동시 요청 시 race condition 방지를 위한 subscriber pattern 구현
- `/auth/refresh` 엔드포인트 순환 호출 방지

## Changes
- `frontend/src/lib/api/auth.ts`: `refreshAccessToken()` 함수 추가
- `frontend/src/lib/api/client.ts`: 401 응답 시 자동 갱신 로직 구현

## Test Plan
- [ ] Access token 만료 후 API 호출 시 자동 갱신 확인
- [ ] 동시 요청 시 race condition 없음 확인
- [ ] Refresh 실패 시 로그인 리다이렉트 확인
- [ ] `/auth/me`, 로그인/회원가입 페이지에서 refresh 시도 안함 확인

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)