### PR TITLE
fix: resolve case detail 404 by switching from query to path params

### DIFF
--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -226,23 +226,23 @@ export async function clearAuth(page: Page): Promise<void> {
 
 /**
  * 특정 케이스 페이지로 이동 (인증 필요)
- * Uses query parameter format with trailing slash for static hosting compatibility
+ * Uses path-based route format for S3 static hosting compatibility
  * @param page Playwright Page 객체
  * @param caseId 케이스 ID
  */
 export async function navigateToCaseDetail(page: Page, caseId: string): Promise<void> {
-  await page.goto(`/lawyer/cases/detail/?caseId=${caseId}`);
+  await page.goto(`/lawyer/cases/${caseId}/`);
   await page.waitForLoadState('domcontentloaded');
 }
 
 /**
  * 관계도 페이지로 이동 (인증 필요)
- * Uses query parameter format with trailing slash for static hosting compatibility
+ * Uses path-based route format for S3 static hosting compatibility
  * @param page Playwright Page 객체
  * @param caseId 케이스 ID
  */
 export async function navigateToRelationshipPage(page: Page, caseId: string): Promise<void> {
-  await page.goto(`/lawyer/cases/relationship/?caseId=${caseId}`);
+  await page.goto(`/lawyer/cases/${caseId}/relationship/`);
   await page.waitForLoadState('domcontentloaded');
 }
 

--- a/frontend/src/app/client/cases/[id]/ClientCaseDetailClient.tsx
+++ b/frontend/src/app/client/cases/[id]/ClientCaseDetailClient.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import { getClientCaseDetail } from '@/lib/api/client-portal';
 import ProgressTracker from '@/components/client/ProgressTracker';
 import type { ClientCaseDetailResponse, RecentActivity } from '@/types/client-portal';
+import { useCaseIdFromUrl } from '@/hooks/useCaseIdFromUrl';
 
 // Activity Item Component
 function ActivityItem({
@@ -134,7 +135,9 @@ interface ClientCaseDetailClientProps {
   caseId: string;
 }
 
-export default function ClientCaseDetailClient({ caseId }: ClientCaseDetailClientProps) {
+export default function ClientCaseDetailClient({ caseId: paramCaseId }: ClientCaseDetailClientProps) {
+  // Use URL path for case ID (handles static export fallback)
+  const caseId = useCaseIdFromUrl(paramCaseId);
   const [caseData, setCaseData] = useState<ClientCaseDetailResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/app/client/cases/detail/page.tsx
+++ b/frontend/src/app/client/cases/detail/page.tsx
@@ -1,21 +1,32 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { Suspense, useState, useEffect } from 'react';
+/**
+ * Legacy Client Case Detail Page (Query Parameter Route)
+ *
+ * This page exists for backwards compatibility with old URLs like:
+ * /client/cases/detail?caseId=xxx
+ *
+ * It redirects to the new path-based route: /client/cases/{caseId}/
+ * which avoids S3 redirect issues that strip query parameters.
+ */
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
 import Link from 'next/link';
-import ClientCaseDetailClient from '../[id]/ClientCaseDetailClient';
 
-function ClientCaseDetailContent() {
+function ClientCaseDetailRedirect() {
   const searchParams = useSearchParams();
-  const [isHydrated, setIsHydrated] = useState(false);
-
-  useEffect(() => {
-    setIsHydrated(true);
-  }, []);
+  const router = useRouter();
 
   const caseId = searchParams.get('caseId');
 
-  if (!isHydrated) {
+  useEffect(() => {
+    if (caseId) {
+      router.replace(`/client/cases/${caseId}/`);
+    }
+  }, [caseId, router]);
+
+  if (caseId) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
@@ -23,30 +34,25 @@ function ClientCaseDetailContent() {
     );
   }
 
-  if (!caseId) {
-    console.error('[ClientCaseDetailPage] caseId is null. URL:', typeof window !== 'undefined' ? window.location.href : 'SSR');
-    return (
-      <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
-        <p className="text-lg text-[var(--color-text-secondary)]">
-          조회할 사건 ID가 전달되지 않았습니다.
-        </p>
-        <Link
-          href="/client/cases"
-          className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
-        >
-          케이스 목록으로 가기
-        </Link>
-      </div>
-    );
-  }
-
-  return <ClientCaseDetailClient caseId={caseId} />;
+  return (
+    <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
+      <p className="text-lg text-[var(--color-text-secondary)]">
+        조회할 사건 ID가 전달되지 않았습니다.
+      </p>
+      <Link
+        href="/client/cases"
+        className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
+      >
+        케이스 목록으로 가기
+      </Link>
+    </div>
+  );
 }
 
 export default function ClientCaseDetailByQuery() {
   return (
     <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" /></div>}>
-      <ClientCaseDetailContent />
+      <ClientCaseDetailRedirect />
     </Suspense>
   );
 }

--- a/frontend/src/app/detective/cases/[id]/DetectiveCaseDetailClient.tsx
+++ b/frontend/src/app/detective/cases/[id]/DetectiveCaseDetailClient.tsx
@@ -17,12 +17,15 @@ import {
   type CaseDetailData,
   type FieldRecord,
 } from '@/lib/api/detective-portal';
+import { useCaseIdFromUrl } from '@/hooks/useCaseIdFromUrl';
 
 interface DetectiveCaseDetailClientProps {
   caseId: string;
 }
 
-export default function DetectiveCaseDetailClient({ caseId }: DetectiveCaseDetailClientProps) {
+export default function DetectiveCaseDetailClient({ caseId: paramCaseId }: DetectiveCaseDetailClientProps) {
+  // Use URL path for case ID (handles static export fallback)
+  const caseId = useCaseIdFromUrl(paramCaseId);
   const router = useRouter();
 
   const [caseDetail, setCaseDetail] = useState<CaseDetailData | null>(null);

--- a/frontend/src/app/detective/cases/detail/page.tsx
+++ b/frontend/src/app/detective/cases/detail/page.tsx
@@ -1,21 +1,32 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { Suspense, useState, useEffect } from 'react';
+/**
+ * Legacy Detective Case Detail Page (Query Parameter Route)
+ *
+ * This page exists for backwards compatibility with old URLs like:
+ * /detective/cases/detail?caseId=xxx
+ *
+ * It redirects to the new path-based route: /detective/cases/{caseId}/
+ * which avoids S3 redirect issues that strip query parameters.
+ */
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
 import Link from 'next/link';
-import DetectiveCaseDetailClient from '../[id]/DetectiveCaseDetailClient';
 
-function DetectiveCaseDetailContent() {
+function DetectiveCaseDetailRedirect() {
   const searchParams = useSearchParams();
-  const [isHydrated, setIsHydrated] = useState(false);
-
-  useEffect(() => {
-    setIsHydrated(true);
-  }, []);
+  const router = useRouter();
 
   const caseId = searchParams.get('caseId');
 
-  if (!isHydrated) {
+  useEffect(() => {
+    if (caseId) {
+      router.replace(`/detective/cases/${caseId}/`);
+    }
+  }, [caseId, router]);
+
+  if (caseId) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
@@ -23,30 +34,25 @@ function DetectiveCaseDetailContent() {
     );
   }
 
-  if (!caseId) {
-    console.error('[DetectiveCaseDetailPage] caseId is null. URL:', typeof window !== 'undefined' ? window.location.href : 'SSR');
-    return (
-      <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
-        <p className="text-lg text-[var(--color-text-secondary)]">
-          조회할 사건 ID가 전달되지 않았습니다.
-        </p>
-        <Link
-          href="/detective/cases"
-          className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
-        >
-          케이스 목록으로 가기
-        </Link>
-      </div>
-    );
-  }
-
-  return <DetectiveCaseDetailClient caseId={caseId} />;
+  return (
+    <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
+      <p className="text-lg text-[var(--color-text-secondary)]">
+        조회할 사건 ID가 전달되지 않았습니다.
+      </p>
+      <Link
+        href="/detective/cases"
+        className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
+      >
+        케이스 목록으로 가기
+      </Link>
+    </div>
+  );
 }
 
 export default function DetectiveCaseDetailByQuery() {
   return (
     <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" /></div>}>
-      <DetectiveCaseDetailContent />
+      <DetectiveCaseDetailRedirect />
     </Suspense>
   );
 }

--- a/frontend/src/app/lawyer/cases/[id]/LawyerCaseDetailClient.tsx
+++ b/frontend/src/app/lawyer/cases/[id]/LawyerCaseDetailClient.tsx
@@ -7,7 +7,7 @@
  * Client-side component for case detail view with evidence list and AI summary.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { apiClient } from '@/lib/api/client';
@@ -18,6 +18,7 @@ import { ApiCase } from '@/lib/api/cases';
 import { getCaseDetailPath, getLawyerCasePath } from '@/lib/portalPaths';
 import { PrecedentPanel } from '@/components/precedent';
 import { PartyGraph } from '@/components/party/PartyGraph';
+import { useCaseIdFromUrl } from '@/hooks/useCaseIdFromUrl';
 
 interface CaseDetail {
   id: string;
@@ -75,8 +76,11 @@ interface LawyerCaseDetailClientProps {
   id: string;
 }
 
-export default function LawyerCaseDetailClient({ id }: LawyerCaseDetailClientProps) {
+export default function LawyerCaseDetailClient({ id: paramId }: LawyerCaseDetailClientProps) {
   const router = useRouter();
+
+  // Use URL path for case ID (handles static export fallback)
+  const id = useCaseIdFromUrl(paramId);
 
   // caseId 설정 - 빈 값이면 빈 문자열 유지 (API 레벨에서 방어됨)
   const caseId = id || '';

--- a/frontend/src/app/lawyer/cases/[id]/assets/AssetSheetClient.tsx
+++ b/frontend/src/app/lawyer/cases/[id]/assets/AssetSheetClient.tsx
@@ -16,6 +16,7 @@ import { AssetForm, AssetTable, DivisionSummary } from '@/components/lawyer/asse
 import type { Asset as ComponentAsset, DivisionSummary as ComponentDivisionSummary } from '@/types/asset';
 import type { LegacyAsset as Asset, CreateAssetRequest } from '@/types/asset';
 import { getCaseDetailPath, getLawyerCasePath } from '@/lib/portalPaths';
+import { useCaseIdFromUrl } from '@/hooks/useCaseIdFromUrl';
 
 type ViewMode = 'table' | 'form';
 
@@ -23,7 +24,9 @@ interface AssetSheetClientProps {
   caseId: string;
 }
 
-export default function AssetSheetClient({ caseId }: AssetSheetClientProps) {
+export default function AssetSheetClient({ caseId: paramCaseId }: AssetSheetClientProps) {
+  // Use URL path for case ID (handles static export fallback)
+  const caseId = useCaseIdFromUrl(paramCaseId);
   const router = useRouter();
   const assetsPath = getLawyerCasePath('assets', caseId);
   const detailPath = getCaseDetailPath('lawyer', caseId, { returnUrl: assetsPath });

--- a/frontend/src/app/lawyer/cases/[id]/assets/CaseAssetsClient.tsx
+++ b/frontend/src/app/lawyer/cases/[id]/assets/CaseAssetsClient.tsx
@@ -10,12 +10,15 @@
 import Link from 'next/link';
 import { AssetDivisionForm } from '@/components/case/AssetDivisionForm';
 import { getCaseDetailPath, getLawyerCasePath } from '@/lib/portalPaths';
+import { useCaseIdFromUrl } from '@/hooks/useCaseIdFromUrl';
 
 interface CaseAssetsClientProps {
   caseId: string;
 }
 
-export default function CaseAssetsClient({ caseId }: CaseAssetsClientProps) {
+export default function CaseAssetsClient({ caseId: paramCaseId }: CaseAssetsClientProps) {
+  // Use URL path for case ID (handles static export fallback)
+  const caseId = useCaseIdFromUrl(paramCaseId);
   const assetsPath = getLawyerCasePath('assets', caseId);
   const detailPath = getCaseDetailPath('lawyer', caseId, { returnUrl: assetsPath });
   const evidenceTabPath = getCaseDetailPath('lawyer', caseId, {

--- a/frontend/src/app/lawyer/cases/[id]/procedure/ProcedureClient.tsx
+++ b/frontend/src/app/lawyer/cases/[id]/procedure/ProcedureClient.tsx
@@ -6,6 +6,7 @@
 'use client';
 
 import { useProcedure } from '@/hooks/useProcedure';
+import { useCaseIdFromUrl } from '@/hooks/useCaseIdFromUrl';
 import { ProcedureTimeline } from '@/components/procedure';
 import Link from 'next/link';
 import { getCaseDetailPath, getLawyerCasePath } from '@/lib/portalPaths';
@@ -14,7 +15,9 @@ interface ProcedureClientProps {
   caseId: string;
 }
 
-export default function ProcedureClient({ caseId }: ProcedureClientProps) {
+export default function ProcedureClient({ caseId: paramCaseId }: ProcedureClientProps) {
+  // Use URL path for case ID (handles static export fallback)
+  const caseId = useCaseIdFromUrl(paramCaseId);
   const {
     stages,
     currentStage,

--- a/frontend/src/app/lawyer/cases/[id]/relations/CaseRelationsClient.tsx
+++ b/frontend/src/app/lawyer/cases/[id]/relations/CaseRelationsClient.tsx
@@ -10,12 +10,15 @@
 import Link from 'next/link';
 import { CaseRelationsGraph } from '@/components/case/CaseRelationsGraph';
 import { getCaseDetailPath, getLawyerCasePath } from '@/lib/portalPaths';
+import { useCaseIdFromUrl } from '@/hooks/useCaseIdFromUrl';
 
 interface CaseRelationsClientProps {
   caseId: string;
 }
 
-export default function CaseRelationsClient({ caseId }: CaseRelationsClientProps) {
+export default function CaseRelationsClient({ caseId: paramCaseId }: CaseRelationsClientProps) {
+  // Use URL path for case ID (handles static export fallback)
+  const caseId = useCaseIdFromUrl(paramCaseId);
   const relationsPath = getLawyerCasePath('relations', caseId);
   const detailPath = getCaseDetailPath('lawyer', caseId, { returnUrl: relationsPath });
   const evidenceTabPath = getCaseDetailPath('lawyer', caseId, {

--- a/frontend/src/app/lawyer/cases/[id]/relationship/RelationshipClient.tsx
+++ b/frontend/src/app/lawyer/cases/[id]/relationship/RelationshipClient.tsx
@@ -15,12 +15,15 @@ import RelationshipLegend from '@/components/relationship/RelationshipLegend';
 import { getCaseRelationships, getMockRelationshipGraph } from '@/lib/api/relationship';
 import { RelationshipGraph } from '@/types/relationship';
 import { getCaseDetailPath, getLawyerCasePath } from '@/lib/portalPaths';
+import { useCaseIdFromUrl } from '@/hooks/useCaseIdFromUrl';
 
 interface RelationshipClientProps {
   caseId: string;
 }
 
-export default function RelationshipClient({ caseId }: RelationshipClientProps) {
+export default function RelationshipClient({ caseId: paramCaseId }: RelationshipClientProps) {
+  // Use URL path for case ID (handles static export fallback)
+  const caseId = useCaseIdFromUrl(paramCaseId);
   const router = useRouter();
   const [graph, setGraph] = useState<RelationshipGraph | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/frontend/src/app/lawyer/cases/assets/page.tsx
+++ b/frontend/src/app/lawyer/cases/assets/page.tsx
@@ -1,37 +1,52 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
-import Link from 'next/link';
-import CaseAssetsClient from '../[id]/assets/CaseAssetsClient';
+/**
+ * Legacy Assets Page (Query Parameter Route)
+ * Redirects to path-based route: /lawyer/cases/{caseId}/assets/
+ */
 
-function LawyerCaseAssetsContent() {
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
+import Link from 'next/link';
+
+function LawyerCaseAssetsRedirect() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const caseId = searchParams.get('caseId');
 
-  if (!caseId) {
+  useEffect(() => {
+    if (caseId) {
+      router.replace(`/lawyer/cases/${caseId}/assets/`);
+    }
+  }, [caseId, router]);
+
+  if (caseId) {
     return (
-      <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
-        <p className="text-lg text-[var(--color-text-secondary)]">
-          조회할 사건 ID가 전달되지 않았습니다.
-        </p>
-        <Link
-          href="/lawyer/cases"
-          className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
-        >
-          케이스 목록으로 가기
-        </Link>
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
       </div>
     );
   }
 
-  return <CaseAssetsClient caseId={caseId} />;
+  return (
+    <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
+      <p className="text-lg text-[var(--color-text-secondary)]">
+        조회할 사건 ID가 전달되지 않았습니다.
+      </p>
+      <Link
+        href="/lawyer/cases"
+        className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
+      >
+        케이스 목록으로 가기
+      </Link>
+    </div>
+  );
 }
 
 export default function LawyerCaseAssetsByQuery() {
   return (
     <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" /></div>}>
-      <LawyerCaseAssetsContent />
+      <LawyerCaseAssetsRedirect />
     </Suspense>
   );
 }

--- a/frontend/src/app/lawyer/cases/detail/page.tsx
+++ b/frontend/src/app/lawyer/cases/detail/page.tsx
@@ -1,24 +1,37 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { Suspense, useState, useEffect } from 'react';
+/**
+ * Legacy Case Detail Page (Query Parameter Route)
+ *
+ * This page exists for backwards compatibility with old URLs like:
+ * /lawyer/cases/detail?caseId=xxx
+ *
+ * It redirects to the new path-based route: /lawyer/cases/{caseId}/
+ * which avoids S3 redirect issues that strip query parameters.
+ */
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
 import Link from 'next/link';
-import CaseDetailClient from '@/components/case/CaseDetailClient';
 
-function LawyerCaseDetailContent() {
+function LawyerCaseDetailRedirect() {
   const searchParams = useSearchParams();
-  const [isHydrated, setIsHydrated] = useState(false);
-
-  // Wait for hydration to complete before checking caseId
-  useEffect(() => {
-    setIsHydrated(true);
-  }, []);
+  const router = useRouter();
 
   const caseId = searchParams.get('caseId');
   const returnUrl = searchParams.get('returnUrl');
 
-  // Show loading while hydrating (prevents flash of error message)
-  if (!isHydrated) {
+  useEffect(() => {
+    // Redirect to path-based route if caseId is present
+    if (caseId) {
+      const newPath = `/lawyer/cases/${caseId}/`;
+      const queryParams = returnUrl ? `?returnUrl=${encodeURIComponent(returnUrl)}` : '';
+      router.replace(newPath + queryParams);
+    }
+  }, [caseId, returnUrl, router]);
+
+  // Show loading while redirecting
+  if (caseId) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
@@ -26,41 +39,26 @@ function LawyerCaseDetailContent() {
     );
   }
 
-  // Debug log to help identify the issue
-  if (!caseId) {
-    console.error('[CaseDetailPage] caseId is null. URL:', typeof window !== 'undefined' ? window.location.href : 'SSR');
-    console.error('[CaseDetailPage] searchParams:', searchParams.toString());
-  }
-
-  if (!caseId) {
-    return (
-      <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
-        <p className="text-lg text-[var(--color-text-secondary)]">
-          조회할 사건 ID가 전달되지 않았습니다.
-        </p>
-        <Link
-          href="/lawyer/cases"
-          className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
-        >
-          케이스 목록으로 가기
-        </Link>
-      </div>
-    );
-  }
-
+  // No caseId provided - show error state
   return (
-    <CaseDetailClient
-      id={caseId}
-      apiBasePath="/lawyer"
-      defaultReturnUrl={returnUrl || '/lawyer/cases'}
-    />
+    <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
+      <p className="text-lg text-[var(--color-text-secondary)]">
+        조회할 사건 ID가 전달되지 않았습니다.
+      </p>
+      <Link
+        href="/lawyer/cases"
+        className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
+      >
+        케이스 목록으로 가기
+      </Link>
+    </div>
   );
 }
 
 export default function LawyerCaseDetailByQuery() {
   return (
     <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" /></div>}>
-      <LawyerCaseDetailContent />
+      <LawyerCaseDetailRedirect />
     </Suspense>
   );
 }

--- a/frontend/src/app/lawyer/cases/procedure/page.tsx
+++ b/frontend/src/app/lawyer/cases/procedure/page.tsx
@@ -1,37 +1,52 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
-import Link from 'next/link';
-import ProcedureClient from '../[id]/procedure/ProcedureClient';
+/**
+ * Legacy Procedure Page (Query Parameter Route)
+ * Redirects to path-based route: /lawyer/cases/{caseId}/procedure/
+ */
 
-function LawyerCaseProcedureContent() {
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
+import Link from 'next/link';
+
+function LawyerCaseProcedureRedirect() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const caseId = searchParams.get('caseId');
 
-  if (!caseId) {
+  useEffect(() => {
+    if (caseId) {
+      router.replace(`/lawyer/cases/${caseId}/procedure/`);
+    }
+  }, [caseId, router]);
+
+  if (caseId) {
     return (
-      <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
-        <p className="text-lg text-[var(--color-text-secondary)]">
-          조회할 사건 ID가 전달되지 않았습니다.
-        </p>
-        <Link
-          href="/lawyer/cases"
-          className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
-        >
-          케이스 목록으로 가기
-        </Link>
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
       </div>
     );
   }
 
-  return <ProcedureClient caseId={caseId} />;
+  return (
+    <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
+      <p className="text-lg text-[var(--color-text-secondary)]">
+        조회할 사건 ID가 전달되지 않았습니다.
+      </p>
+      <Link
+        href="/lawyer/cases"
+        className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
+      >
+        케이스 목록으로 가기
+      </Link>
+    </div>
+  );
 }
 
 export default function LawyerCaseProcedureByQuery() {
   return (
     <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" /></div>}>
-      <LawyerCaseProcedureContent />
+      <LawyerCaseProcedureRedirect />
     </Suspense>
   );
 }

--- a/frontend/src/app/lawyer/cases/relations/page.tsx
+++ b/frontend/src/app/lawyer/cases/relations/page.tsx
@@ -1,37 +1,52 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
-import Link from 'next/link';
-import CaseRelationsClient from '../[id]/relations/CaseRelationsClient';
+/**
+ * Legacy Relations Page (Query Parameter Route)
+ * Redirects to path-based route: /lawyer/cases/{caseId}/relations/
+ */
 
-function LawyerCaseRelationsContent() {
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
+import Link from 'next/link';
+
+function LawyerCaseRelationsRedirect() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const caseId = searchParams.get('caseId');
 
-  if (!caseId) {
+  useEffect(() => {
+    if (caseId) {
+      router.replace(`/lawyer/cases/${caseId}/relations/`);
+    }
+  }, [caseId, router]);
+
+  if (caseId) {
     return (
-      <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
-        <p className="text-lg text-[var(--color-text-secondary)]">
-          조회할 사건 ID가 전달되지 않았습니다.
-        </p>
-        <Link
-          href="/lawyer/cases"
-          className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
-        >
-          케이스 목록으로 가기
-        </Link>
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
       </div>
     );
   }
 
-  return <CaseRelationsClient caseId={caseId} />;
+  return (
+    <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
+      <p className="text-lg text-[var(--color-text-secondary)]">
+        조회할 사건 ID가 전달되지 않았습니다.
+      </p>
+      <Link
+        href="/lawyer/cases"
+        className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
+      >
+        케이스 목록으로 가기
+      </Link>
+    </div>
+  );
 }
 
 export default function LawyerCaseRelationsByQuery() {
   return (
     <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" /></div>}>
-      <LawyerCaseRelationsContent />
+      <LawyerCaseRelationsRedirect />
     </Suspense>
   );
 }

--- a/frontend/src/app/lawyer/cases/relationship/page.tsx
+++ b/frontend/src/app/lawyer/cases/relationship/page.tsx
@@ -1,37 +1,52 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
-import Link from 'next/link';
-import RelationshipClient from '../[id]/relationship/RelationshipClient';
+/**
+ * Legacy Relationship Page (Query Parameter Route)
+ * Redirects to path-based route: /lawyer/cases/{caseId}/relationship/
+ */
 
-function LawyerCaseRelationshipContent() {
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
+import Link from 'next/link';
+
+function LawyerCaseRelationshipRedirect() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const caseId = searchParams.get('caseId');
 
-  if (!caseId) {
+  useEffect(() => {
+    if (caseId) {
+      router.replace(`/lawyer/cases/${caseId}/relationship/`);
+    }
+  }, [caseId, router]);
+
+  if (caseId) {
     return (
-      <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
-        <p className="text-lg text-[var(--color-text-secondary)]">
-          조회할 사건 ID가 전달되지 않았습니다.
-        </p>
-        <Link
-          href="/lawyer/cases"
-          className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
-        >
-          케이스 목록으로 가기
-        </Link>
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
       </div>
     );
   }
 
-  return <RelationshipClient caseId={caseId} />;
+  return (
+    <div className="min-h-[400px] flex flex-col items-center justify-center text-center space-y-4">
+      <p className="text-lg text-[var(--color-text-secondary)]">
+        조회할 사건 ID가 전달되지 않았습니다.
+      </p>
+      <Link
+        href="/lawyer/cases"
+        className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-lg hover:bg-[var(--color-primary-hover)] transition-colors"
+      >
+        케이스 목록으로 가기
+      </Link>
+    </div>
+  );
 }
 
 export default function LawyerCaseRelationshipByQuery() {
   return (
     <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" /></div>}>
-      <LawyerCaseRelationshipContent />
+      <LawyerCaseRelationshipRedirect />
     </Suspense>
   );
 }

--- a/frontend/src/hooks/useCaseIdFromUrl.ts
+++ b/frontend/src/hooks/useCaseIdFromUrl.ts
@@ -1,0 +1,56 @@
+/**
+ * Hook to extract case ID from URL path for static export fallback support.
+ *
+ * When Next.js static export is served via CloudFront/S3, dynamic routes not
+ * listed in generateStaticParams get served with a fallback HTML file.
+ * The params.id from build time won't match the actual URL.
+ *
+ * This hook extracts the real case ID from the browser's URL path.
+ *
+ * @param fallbackId - The ID passed from page params (build-time value)
+ * @returns The effective case ID (URL path preferred over fallback)
+ */
+
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+/**
+ * Extract case ID from URL path.
+ * Matches patterns like:
+ * - /lawyer/cases/{id}/
+ * - /lawyer/cases/{id}/procedure/
+ * - /client/cases/{id}/
+ * - /detective/cases/{id}/
+ */
+function extractCaseIdFromPath(pathname: string): string | null {
+  // Match /{role}/cases/{id} or /{role}/cases/{id}/{section}
+  const match = pathname.match(/^\/(lawyer|client|detective|staff)\/cases\/([^/]+)/);
+  return match ? match[2] : null;
+}
+
+/**
+ * Hook to get the effective case ID, preferring URL path over build-time params.
+ *
+ * @param fallbackId - The ID from page params (may be incorrect for dynamic routes in static export)
+ * @returns The effective case ID extracted from the current URL path
+ *
+ * @example
+ * ```tsx
+ * // In a client component
+ * function CaseDetailClient({ id }: { id: string }) {
+ *   const caseId = useCaseIdFromUrl(id);
+ *   // caseId will be the actual ID from URL, not the build-time params.id
+ * }
+ * ```
+ */
+export function useCaseIdFromUrl(fallbackId: string): string {
+  const pathname = usePathname();
+  const urlCaseId = extractCaseIdFromPath(pathname);
+
+  // Prefer URL path over build-time params
+  // This handles CloudFront serving pre-rendered HTML for dynamic routes
+  return urlCaseId || fallbackId;
+}
+
+export default useCaseIdFromUrl;

--- a/infrastructure/cloudfront-functions/README.md
+++ b/infrastructure/cloudfront-functions/README.md
@@ -1,0 +1,102 @@
+# CloudFront Functions for LEH
+
+This directory contains CloudFront Functions for handling dynamic routing in the LEH frontend.
+
+## Dynamic Route Handler
+
+**File:** `dynamic-route-handler.js`
+
+### Purpose
+
+Next.js static export (`output: 'export'`) only generates HTML files for IDs specified in `generateStaticParams`. When users access dynamic case IDs (like `case_e5db1573bb04`) that weren't pre-rendered, S3 returns a 404.
+
+This CloudFront Function solves this by:
+1. Detecting requests for case detail paths
+2. Rewriting the origin path to serve a pre-rendered fallback page
+3. Preserving the original URL in the browser
+
+The client-side JavaScript (`useCaseIdFromUrl` hook) reads the actual URL to get the correct case ID and fetches the appropriate data.
+
+### How It Works
+
+```
+User Request: /lawyer/cases/case_abc123/
+     ↓
+CloudFront Function detects dynamic ID
+     ↓
+Rewrites origin path to: /lawyer/cases/1/index.html
+     ↓
+S3 serves the pre-rendered page
+     ↓
+Browser URL remains: /lawyer/cases/case_abc123/
+     ↓
+Client-side JS reads URL, extracts "case_abc123"
+     ↓
+API call fetches correct case data
+```
+
+### Deployment Steps
+
+1. **Go to CloudFront Console**
+   - Open AWS Console → CloudFront → Functions
+
+2. **Create New Function**
+   - Click "Create function"
+   - Name: `leh-dynamic-route-handler`
+   - Runtime: `cloudfront-js-1.0`
+
+3. **Add Code**
+   - Copy the contents of `dynamic-route-handler.js`
+   - Paste into the function editor
+
+4. **Publish**
+   - Click "Publish"
+
+5. **Associate with Distribution**
+   - Go to your CloudFront distribution
+   - Click "Behaviors" tab
+   - Edit the default behavior (or create a new one for `*/cases/*`)
+   - Under "Function associations":
+     - Viewer request: Select `leh-dynamic-route-handler`
+   - Save changes
+
+### Pre-rendered IDs
+
+The function has a hardcoded list of pre-rendered IDs from `generateStaticParams`:
+- `1`, `2`, `3` (development placeholders)
+- `test-case-001`, `test-case-empty` (E2E test IDs)
+
+If you add more pre-rendered IDs, update both:
+1. `generateStaticParams` in page.tsx files
+2. `PRERENDERED_IDS` array in this function
+
+### Testing
+
+After deployment, test these scenarios:
+
+1. **Pre-rendered ID** (should work directly):
+   ```
+   https://your-domain/lawyer/cases/1/
+   ```
+
+2. **Dynamic ID** (should be rewritten but still work):
+   ```
+   https://your-domain/lawyer/cases/case_e5db1573bb04/
+   ```
+
+3. **Sub-routes** (procedure, assets, etc.):
+   ```
+   https://your-domain/lawyer/cases/case_abc/procedure/
+   https://your-domain/lawyer/cases/case_abc/assets/
+   ```
+
+### Alternative: S3 Error Document
+
+If you can't use CloudFront Functions (e.g., using S3 website hosting directly), you can configure S3 to serve a custom error page:
+
+1. Create a generic SPA fallback page
+2. Configure S3 bucket website hosting:
+   - Error document: `index.html` (or custom 404 page)
+3. This returns the fallback for ALL 404s, not just case routes
+
+The CloudFront Function approach is more targeted and recommended.

--- a/infrastructure/cloudfront-functions/dynamic-route-handler.js
+++ b/infrastructure/cloudfront-functions/dynamic-route-handler.js
@@ -1,0 +1,77 @@
+/**
+ * CloudFront Function: Dynamic Route Handler
+ *
+ * This function handles dynamic routes for Next.js static export.
+ * When a request comes in for a path like /lawyer/cases/{dynamic-id}/,
+ * it rewrites the origin path to serve a pre-rendered fallback page.
+ * The client-side JavaScript then reads the actual URL to get the case ID.
+ *
+ * Usage:
+ * 1. Create a CloudFront Function with this code
+ * 2. Associate it with the CloudFront distribution as a "viewer request" function
+ *
+ * Pre-rendered IDs (from generateStaticParams):
+ * - 1, 2, 3, test-case-001, test-case-empty
+ */
+
+// Pre-rendered case IDs that have actual HTML files in S3
+var PRERENDERED_IDS = ['1', '2', '3', 'test-case-001', 'test-case-empty'];
+
+// Fallback ID to use when serving dynamic routes
+var FALLBACK_ID = '1';
+
+/**
+ * Handler function for CloudFront viewer-request event
+ */
+function handler(event) {
+    var request = event.request;
+    var uri = request.uri;
+
+    // Pattern: /{role}/cases/{id}/ or /{role}/cases/{id}/{section}/
+    // Roles: lawyer, client, detective, staff
+    var caseDetailPattern = /^\/(lawyer|client|detective|staff)\/cases\/([^\/]+)(\/(?:procedure|assets|relations|relationship)?)?\/?(index\.html)?$/;
+    var match = uri.match(caseDetailPattern);
+
+    if (match) {
+        var role = match[1];
+        var caseId = match[2];
+        var section = match[3] || '';
+        var indexHtml = match[4] || '';
+
+        // Check if this is a pre-rendered ID
+        var isPrerendered = false;
+        for (var i = 0; i < PRERENDERED_IDS.length; i++) {
+            if (PRERENDERED_IDS[i] === caseId) {
+                isPrerendered = true;
+                break;
+            }
+        }
+
+        // If not pre-rendered, rewrite to fallback
+        if (!isPrerendered) {
+            // Build the new URI with the fallback ID
+            var newUri = '/' + role + '/cases/' + FALLBACK_ID + section;
+
+            // Ensure trailing slash
+            if (!newUri.endsWith('/')) {
+                newUri += '/';
+            }
+
+            // Add index.html for S3 compatibility
+            newUri += 'index.html';
+
+            request.uri = newUri;
+        } else {
+            // For pre-rendered IDs, ensure the URI ends with /index.html
+            if (!uri.endsWith('/index.html')) {
+                if (uri.endsWith('/')) {
+                    request.uri = uri + 'index.html';
+                } else {
+                    request.uri = uri + '/index.html';
+                }
+            }
+        }
+    }
+
+    return request;
+}


### PR DESCRIPTION
## Summary
- S3/CloudFront 리다이렉트 시 쿼리 파라미터가 손실되어 사건 상세 페이지에서 "ID가 전달되지 않았습니다" 오류 발생
- URL 경로 기반 파라미터로 전환하여 문제 해결

## Changes
- `portalPaths.ts`: 쿼리 → 경로 파라미터 방식 변경
- `useCaseIdFromUrl` 훅 생성: URL 경로에서 case ID 추출
- 9개 클라이언트 컴포넌트에 훅 적용
- 7개 레거시 페이지에 리다이렉트 추가
- CloudFront Function 생성 (동적 라우팅 폴백)
- E2E 테스트 헬퍼 URL 패턴 업데이트

## Test plan
- [x] 빌드 성공 확인
- [x] Staging 테스트 완료
- [ ] CloudFront Function 배포 후 검증 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)