### PR TITLE
feat(security): AWS Security Hardening - OIDC, OAC, IAM Least Privilege

### DIFF
--- a/.github/workflows/deploy_paralegal.yml
+++ b/.github/workflows/deploy_paralegal.yml
@@ -46,12 +46,12 @@ jobs:
             echo "CF_DIST=${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_STAGING || secrets.CLOUDFRONT_DISTRIBUTION_ID }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS Credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ap-northeast-2
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::540261961975:role/github-actions-leh-deploy
+          role-session-name: github-actions-${{ github.run_id }}
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
## Summary
- **#343**: S3 버킷 접근을 CloudFront OAC로 제한
- **#344**: Lambda IAM 정책을 최소 권한으로 변경
- **#345**: GitHub Actions OIDC 연합 인증 전환

## Changes

### S3 + CloudFront (Issue #343)
- CloudFront Origin을 S3 REST Endpoint + OAC로 변경
- S3 버킷 정책을 CloudFront OAC만 허용하도록 수정
- S3 직접 접근 차단 확인 (403)

### Lambda IAM (Issue #344)
- `AmazonS3FullAccess` → `leh-lambda-s3-least-privilege`
- `AmazonDynamoDBFullAccess` → `leh-lambda-dynamodb-least-privilege`
- 리소스 범위: `leh-evidence-*`, `leh_*` 테이블만 허용

### GitHub Actions OIDC (Issue #345)
- 정적 Access Key → OIDC 연합 인증
- Role: `github-actions-leh-deploy`
- 15분 만료 토큰으로 보안 강화

## Test Plan
- [x] CloudFront 접근: 200 OK
- [x] S3 직접 접근: 403 Forbidden
- [x] API Health: 200 OK
- [ ] GitHub Actions 배포 테스트 (OIDC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)