### PR TITLE
chore(db): merge alembic migration heads & apply lssp_003

### DIFF
--- a/backend/alembic/versions/724a7e3ccf5e_merge_lssp003_and_cascade_delete.py
+++ b/backend/alembic/versions/724a7e3ccf5e_merge_lssp003_and_cascade_delete.py
@@ -7,9 +7,6 @@ Create Date: 2025-12-19 17:11:48.356988
 """
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision: str = '724a7e3ccf5e'


### PR DESCRIPTION
## Summary
- Alembic 마이그레이션 head 2개를 1개로 머지
- `lssp_003_civil_code_ref` 마이그레이션 RDS에 적용 완료
- 이전 PR #360의 test_data 파일들 포함

## Changes
- `backend/alembic/versions/724a7e3ccf5e_merge_lssp003_and_cascade_delete.py` 추가

## Test plan
- [x] `alembic heads` → 단일 head 확인
- [x] RDS에 마이그레이션 적용 완료
- [x] DynamoDB, Qdrant 연결 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)