### PR TITLE
feat(frontend): add centralized brand config via environment variables

### DIFF
--- a/frontend/src/__tests__/landing/seo.test.tsx
+++ b/frontend/src/__tests__/landing/seo.test.tsx
@@ -13,6 +13,7 @@
  */
 
 import { metadata } from '../../app/layout';
+import { BRAND } from '@/config/brand';
 
 describe('Plan 3.19.2 - SEO Optimization', () => {
   describe('Title Tag', () => {
@@ -23,7 +24,7 @@ describe('Plan 3.19.2 - SEO Optimization', () => {
 
     test('title should include brand name and value proposition', () => {
       const title = metadata.title as string;
-      expect(title).toContain('Legal Evidence Hub');
+      expect(title).toContain(BRAND.name);
       expect(title).toContain('AI');
     });
 
@@ -170,9 +171,9 @@ describe('Plan 3.19.2 - SEO Optimization', () => {
       expect(Array.isArray(metadata.authors)).toBe(true);
     });
 
-    test('should include Legal Evidence Hub as author', () => {
+    test('should include brand name as author', () => {
       const authors = metadata.authors as Array<{ name: string }>;
-      expect(authors.some((author) => author.name === 'Legal Evidence Hub')).toBe(
+      expect(authors.some((author) => author.name === BRAND.name)).toBe(
         true
       );
     });

--- a/frontend/src/__tests__/pages/client-portal.test.tsx
+++ b/frontend/src/__tests__/pages/client-portal.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ClientEvidencePortal from '@/app/portal/page';
+import { BRAND } from '@/config/brand';
 
 jest.mock('next/navigation', () => ({
     useRouter: () => ({
@@ -16,7 +17,7 @@ describe('Plan 3.7 - Client Evidence Submission Portal', () => {
     test('renders only the required portal elements: logo, guidance, single upload zone, and feedback area', () => {
         render(<ClientEvidencePortal />);
 
-        expect(screen.getByText(/Legal Evidence Hub/i)).toBeInTheDocument();
+        expect(screen.getByText(new RegExp(BRAND.name, 'i'))).toBeInTheDocument();
         expect(screen.getByText(/안내/)).toBeInTheDocument();
 
         const uploadZones = screen.getAllByTestId('client-upload-zone');

--- a/frontend/src/__tests__/routing/navigation-guard.test.tsx
+++ b/frontend/src/__tests__/routing/navigation-guard.test.tsx
@@ -22,6 +22,7 @@ import { useRouter } from 'next/navigation';
 import HomePage from '../../app/page';
 import LoginPage from '../../app/login/page';
 import * as authApi from '../../lib/api/auth';
+import { BRAND } from '@/config/brand';
 
 // Mock the router
 jest.mock('next/navigation', () => ({
@@ -97,7 +98,7 @@ describe('Plan 3.19.2 - Navigation Guard', () => {
             render(<HomePage />);
 
             // Landing page should be visible - check for main heading
-            expect(screen.getByText(/Legal Evidence Hub가 해결합니다/i)).toBeInTheDocument();
+            expect(screen.getByText(new RegExp(`${BRAND.name}이 해결합니다`, 'i'))).toBeInTheDocument();
         });
 
         test('Unauthenticated user should NOT be redirected from landing page', () => {
@@ -147,7 +148,7 @@ describe('Plan 3.19.2 - Navigation Guard', () => {
 
             // Wait for auth check to complete and login form to appear
             await waitFor(() => {
-                expect(screen.getByRole('heading', { name: /Legal Evidence Hub/i })).toBeInTheDocument();
+                expect(screen.getByRole('heading', { name: new RegExp(BRAND.name, 'i') })).toBeInTheDocument();
             });
         });
 
@@ -162,7 +163,7 @@ describe('Plan 3.19.2 - Navigation Guard', () => {
 
             // Wait for auth check to complete
             await waitFor(() => {
-                expect(screen.getByRole('heading', { name: /Legal Evidence Hub/i })).toBeInTheDocument();
+                expect(screen.getByRole('heading', { name: new RegExp(BRAND.name, 'i') })).toBeInTheDocument();
             });
 
             // Should not redirect
@@ -221,7 +222,7 @@ describe('Plan 3.19.2 - Navigation Guard', () => {
 
             // Wait for auth check to complete
             await waitFor(() => {
-                expect(screen.getByRole('heading', { name: /Legal Evidence Hub/i })).toBeInTheDocument();
+                expect(screen.getByRole('heading', { name: new RegExp(BRAND.name, 'i') })).toBeInTheDocument();
             });
 
             // Should not redirect

--- a/frontend/src/app/__tests__/page.test.tsx
+++ b/frontend/src/app/__tests__/page.test.tsx
@@ -11,6 +11,7 @@
 
 import { render, screen } from '@testing-library/react';
 import LandingPage from '../page';
+import { BRAND } from '@/config/brand';
 
 jest.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({
@@ -45,7 +46,7 @@ describe('Landing Page Integration', () => {
       render(<LandingPage />);
 
       expect(screen.getByRole('navigation')).toBeInTheDocument();
-      expect(screen.getByText('CHAGOK')).toBeInTheDocument();
+      expect(screen.getByText(BRAND.name)).toBeInTheDocument();
     });
 
     it('should render hero section', () => {
@@ -71,7 +72,7 @@ describe('Landing Page Integration', () => {
     it('should render solution section', () => {
       render(<LandingPage />);
 
-      expect(screen.getByRole('heading', { name: /Legal Evidence Hub가 해결합니다/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: new RegExp(`${BRAND.name}이 해결합니다`, 'i') })).toBeInTheDocument();
     });
 
     it('should render how it works section', () => {
@@ -113,7 +114,7 @@ describe('Landing Page Integration', () => {
     it('should render footer', () => {
       render(<LandingPage />);
 
-      expect(screen.getByText(/© 2025 LEH/i)).toBeInTheDocument();
+      expect(screen.getByText(new RegExp(`© 2025 ${BRAND.name}`, 'i'))).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/detective/dashboard/page.tsx
+++ b/frontend/src/app/detective/dashboard/page.tsx
@@ -10,9 +10,10 @@
  */
 
 import { Metadata } from 'next';
+import { BRAND } from '@/config/brand';
 
 export const metadata: Metadata = {
-  title: '대시보드 - Legal Evidence Hub',
+  title: `대시보드 - ${BRAND.name}`,
   description: '탐정 대시보드',
 };
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { Toaster } from 'react-hot-toast';
 import './globals.css';
 import Footer from '@/components/common/Footer';
 import { AppProviders } from './providers';
+import { BRAND } from '@/config/brand';
 
 const APP_BASE_URL =
   process.env.NEXT_PUBLIC_APP_BASE_URL ||
@@ -25,7 +26,7 @@ export const metadata: Metadata = {
     icon: '/logo.svg',
     apple: '/logo.svg',
   },
-  title: 'Legal Evidence Hub - AI 이혼 소송 증거 분석 솔루션',
+  title: `${BRAND.fullName} - AI 이혼 소송 증거 분석 솔루션`,
   description:
     'AI 기반 이혼 소송 증거 자동 분석 및 답변서 초안 생성 서비스. 증거 정리 시간 90% 단축, 14일 무료 체험.',
   keywords: [
@@ -38,12 +39,12 @@ export const metadata: Metadata = {
     '증거관리',
     '소송지원',
   ],
-  authors: [{ name: 'Legal Evidence Hub' }],
+  authors: [{ name: BRAND.name }],
   openGraph: {
-    title: 'Legal Evidence Hub - AI 이혼 소송 증거 분석',
+    title: `${BRAND.fullName} - AI 이혼 소송 증거 분석`,
     description: '증거 정리 시간 90% 단축. AI가 이혼 소송 증거를 자동 분석하고 초안을 작성합니다.',
     url: APP_BASE_URL,
-    siteName: 'Legal Evidence Hub',
+    siteName: BRAND.name,
     locale: 'ko_KR',
     type: 'website',
     images: [
@@ -51,13 +52,13 @@ export const metadata: Metadata = {
         url: `${APP_BASE_URL}/images/og-image.png`,
         width: 1200,
         height: 630,
-        alt: 'Legal Evidence Hub - AI 이혼 소송 증거 분석',
+        alt: `${BRAND.fullName} - AI 이혼 소송 증거 분석`,
       },
     ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Legal Evidence Hub - AI 이혼 소송 증거 분석',
+    title: `${BRAND.fullName} - AI 이혼 소송 증거 분석`,
     description: '증거 정리 시간 90% 단축. AI가 이혼 소송 증거를 자동 분석하고 초안을 작성합니다.',
     images: [`${APP_BASE_URL}/images/twitter-image.png`],
   },
@@ -112,8 +113,8 @@ export default function RootLayout({
             __html: JSON.stringify({
               '@context': 'https://schema.org',
               '@type': 'Organization',
-              name: 'Legal Evidence Hub',
-              alternateName: 'LEH',
+              name: BRAND.name,
+              alternateName: BRAND.nameKo,
               url: APP_BASE_URL,
               logo: `${APP_BASE_URL}/logo.svg`,
               description:
@@ -147,12 +148,12 @@ export default function RootLayout({
             __html: JSON.stringify({
               '@context': 'https://schema.org',
               '@type': 'Product',
-              name: 'Legal Evidence Hub',
+              name: BRAND.name,
               description:
                 'AI 기반 이혼 소송 증거 자동 분석 및 답변서 초안 생성 서비스',
               brand: {
                 '@type': 'Brand',
-                name: 'Legal Evidence Hub',
+                name: BRAND.name,
               },
               offers: {
                 '@type': 'AggregateOffer',

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -20,6 +20,7 @@ import LoginForm from '@/components/auth/LoginForm';
 import { useAuth } from '@/hooks/useAuth';
 import { getDashboardPath, UserRole } from '@/types/user';
 import LandingNav from '@/components/landing/LandingNav';
+import { BRAND } from '@/config/brand';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -78,7 +79,7 @@ export default function LoginPage() {
         <div className="w-full max-w-sm">
           <div className="text-center mb-8">
             <h1 className="text-3xl font-bold text-secondary mb-2">
-              Legal Evidence Hub
+              {BRAND.fullName}
             </h1>
             <p className="text-neutral-600">로그인하여 시작하세요</p>
           </div>

--- a/frontend/src/app/portal/page.tsx
+++ b/frontend/src/app/portal/page.tsx
@@ -3,10 +3,11 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import ClientUploadCard from '@/components/portal/ClientUploadCard';
+import { BRAND } from '@/config/brand';
 
 type UploadStatus = 'idle' | 'uploading' | 'success' | 'error';
 
-const DEFAULT_FIRM_NAME = 'Legal Evidence Hub 로펌';
+const DEFAULT_FIRM_NAME = BRAND.defaultFirmName;
 const DEFAULT_CASE_NAME = '의뢰인 사건';
 const UPLOAD_SIMULATION_DELAY_MS = 800;
 

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -4,10 +4,11 @@
  */
 
 import Link from 'next/link';
+import { BRAND } from '@/config/brand';
 
 export const metadata = {
-  title: '개인정보처리방침 - Legal Evidence Hub',
-  description: 'Legal Evidence Hub 개인정보처리방침 (개인정보보호법 준수)',
+  title: `개인정보처리방침 - ${BRAND.name}`,
+  description: `${BRAND.name} 개인정보처리방침 (개인정보보호법 준수)`,
 };
 
 export default function PrivacyPage() {
@@ -25,7 +26,7 @@ export default function PrivacyPage() {
             </p>
 
             <p className="text-gray-700 dark:text-gray-300 mb-8">
-              Legal Evidence Hub (이하 &quot;회사&quot;)는 개인정보보호법에 따라 이용자의 개인정보 보호 및
+              {BRAND.fullName} (이하 &quot;회사&quot;)는 개인정보보호법에 따라 이용자의 개인정보 보호 및
               권익을 보호하고 개인정보와 관련한 이용자의 고충을 원활하게 처리할 수 있도록
               다음과 같은 처리방침을 두고 있습니다.
             </p>

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -4,10 +4,11 @@
  */
 
 import Link from 'next/link';
+import { BRAND } from '@/config/brand';
 
 export const metadata = {
-  title: '이용약관 - Legal Evidence Hub',
-  description: 'Legal Evidence Hub 서비스 이용약관',
+  title: `이용약관 - ${BRAND.name}`,
+  description: `${BRAND.name} 서비스 이용약관`,
 };
 
 export default function TermsPage() {
@@ -27,7 +28,7 @@ export default function TermsPage() {
             <section className="mb-8">
               <h2 className="text-xl font-semibold mb-4">제1조 (목적)</h2>
               <p className="text-gray-700 dark:text-gray-300">
-                본 약관은 Legal Evidence Hub (이하 &quot;회사&quot;)가 제공하는 AI 기반 법률 증거 분석 서비스
+                본 약관은 {BRAND.fullName} (이하 &quot;회사&quot;)가 제공하는 AI 기반 법률 증거 분석 서비스
                 (이하 &quot;서비스&quot;)의 이용과 관련하여 회사와 이용자 간의 권리, 의무 및 책임사항을
                 규정함을 목적으로 합니다.
               </p>

--- a/frontend/src/components/common/Footer.test.tsx
+++ b/frontend/src/components/common/Footer.test.tsx
@@ -2,6 +2,7 @@
 // T060 - FR-020: Copyright footer with legal links
 import { render, screen } from '@testing-library/react';
 import Footer from './Footer';
+import { BRAND } from '@/config/brand';
 
 describe('Footer 컴포넌트 (T060)', () => {
   it('Footer가 렌더링될 때 주요 법적 링크를 포함해야 한다.', () => {
@@ -18,7 +19,7 @@ describe('Footer 컴포넌트 (T060)', () => {
 
     // Copyright 텍스트 확인 (연도는 동적으로 변경될 수 있으므로 정규식 사용)
     const year = new Date().getFullYear();
-    expect(screen.getByText(new RegExp(`© ${year} Legal Evidence Hub`, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`© ${year} ${BRAND.name}`, 'i'))).toBeInTheDocument();
   });
 
   it('이용약관 링크가 /terms로 연결되어야 한다.', () => {

--- a/frontend/src/components/common/Footer.tsx
+++ b/frontend/src/components/common/Footer.tsx
@@ -2,6 +2,7 @@
 // T060 - FR-020: Copyright footer with legal links
 import React from 'react';
 import Link from 'next/link';
+import { BRAND } from '@/config/brand';
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();
@@ -23,7 +24,7 @@ const Footer = () => {
           </a>
         </div>
         <p className="text-xs text-neutral-600 dark:text-neutral-400">
-          © {currentYear} Legal Evidence Hub. All Rights Reserved. 무단 활용 금지.
+          © {currentYear} {BRAND.name}. All Rights Reserved. 무단 활용 금지.
         </p>
       </div>
     </footer>

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -12,6 +12,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@/components/primitives';
+import { BRAND } from '@/config/brand';
 
 export default function HeroSection() {
   return (
@@ -47,7 +48,7 @@ export default function HeroSection() {
             <div className="relative w-full h-96 bg-white rounded-2xl shadow-2xl overflow-hidden border border-neutral-100">
               <Image
                 src="/images/hero-dashboard.png"
-                alt="Legal Evidence Hub 제품 미리보기 - 증거 관리 대시보드"
+                alt={`${BRAND.fullName} 제품 미리보기 - 증거 관리 대시보드`}
                 fill
                 sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 40vw"
                 className="object-cover"

--- a/frontend/src/components/landing/LandingFooter.tsx
+++ b/frontend/src/components/landing/LandingFooter.tsx
@@ -11,11 +11,12 @@
 
 import Link from 'next/link';
 import { Twitter, Linkedin, Github } from 'lucide-react';
+import { BRAND } from '@/config/brand';
 
 export default function LandingFooter() {
   const companyInfo = {
-    name: 'Legal Evidence Hub',
-    shortName: 'LEH',
+    name: BRAND.fullName,
+    shortName: BRAND.name,
     address: '서울특별시 강남구 테헤란로 123, 10층',
     email: 'contact@legalevidence.hub',
     phone: '02-1234-5678',

--- a/frontend/src/components/landing/LandingNav.tsx
+++ b/frontend/src/components/landing/LandingNav.tsx
@@ -13,6 +13,7 @@
 import { useCallback, useState } from 'react';
 import Link from 'next/link';
 import { Logo } from '@/components/shared/Logo';
+import { BRAND } from '@/config/brand';
 
 interface LandingNavProps {
   isScrolled?: boolean;
@@ -68,7 +69,7 @@ export default function LandingNav({
         <div className="flex items-center">
           <Link href="/" className="flex items-center space-x-2">
             <Logo size="sm" />
-            <span className="text-2xl font-bold text-secondary">CHAGOK</span>
+            <span className="text-2xl font-bold text-secondary">{BRAND.name}</span>
           </Link>
         </div>
 

--- a/frontend/src/components/landing/SolutionSection.tsx
+++ b/frontend/src/components/landing/SolutionSection.tsx
@@ -3,7 +3,7 @@
  * Plan 3.19.1 - Solution (3가지 핵심 기능)
  *
  * Features:
- * - Section title: "Legal Evidence Hub가 해결합니다"
+ * - Section title: "CHAGOK이 해결합니다"
  * - 3-column layout showcasing core features
  * - Each feature: icon, heading, description
  * - Card-based design with shadows
@@ -11,6 +11,7 @@
  */
 
 import { Brain, Clock, FileCheck } from 'lucide-react';
+import { BRAND } from '@/config/brand';
 
 export default function SolutionSection() {
   const features = [
@@ -47,7 +48,7 @@ export default function SolutionSection() {
         <div className="space-y-12">
           {/* Section Title */}
           <h2 className="text-4xl font-bold text-secondary text-center">
-            Legal Evidence Hub가 해결합니다
+            {BRAND.name}이 해결합니다
           </h2>
 
           {/* Features Grid - Responsive: 1-col mobile, 2-col tablet, 3-col desktop */}

--- a/frontend/src/components/landing/__tests__/LandingFooter.test.tsx
+++ b/frontend/src/components/landing/__tests__/LandingFooter.test.tsx
@@ -12,6 +12,7 @@
 
 import { render, screen } from '@testing-library/react';
 import LandingFooter from '../LandingFooter';
+import { BRAND } from '@/config/brand';
 
 describe('LandingFooter Component', () => {
   describe('Company Information Column', () => {
@@ -19,7 +20,7 @@ describe('LandingFooter Component', () => {
       render(<LandingFooter />);
 
       // Should have logo or company name (multiple instances)
-      const companyNames = screen.getAllByText(/LEH|Legal Evidence Hub/i);
+      const companyNames = screen.getAllByText(new RegExp(BRAND.name, 'i'));
       expect(companyNames.length).toBeGreaterThanOrEqual(1);
     });
 
@@ -166,8 +167,8 @@ describe('LandingFooter Component', () => {
     it('should have header for company info section', () => {
       render(<LandingFooter />);
 
-      // Should have "Legal Evidence Hub" heading
-      const heading = screen.getByRole('heading', { name: /Legal Evidence Hub/i });
+      // Should have brand name heading
+      const heading = screen.getByRole('heading', { name: new RegExp(BRAND.name, 'i') });
       expect(heading).toBeInTheDocument();
     });
 
@@ -179,7 +180,7 @@ describe('LandingFooter Component', () => {
       expect(companyLink).toBeInTheDocument();
 
       // Check that the heading is inside the link
-      const heading = screen.getByRole('heading', { name: /Legal Evidence Hub/i });
+      const heading = screen.getByRole('heading', { name: new RegExp(BRAND.name, 'i') });
       expect(companyLink).toContainElement(heading);
     });
 

--- a/frontend/src/components/landing/__tests__/LandingNav.test.tsx
+++ b/frontend/src/components/landing/__tests__/LandingNav.test.tsx
@@ -11,6 +11,7 @@
 
 import { render, screen } from '@testing-library/react';
 import LandingNav from '../LandingNav';
+import { BRAND } from '@/config/brand';
 
 describe('LandingNav Component', () => {
   describe('Structure and Layout', () => {
@@ -141,7 +142,7 @@ describe('LandingNav Component', () => {
     it('should use Deep Trust Blue for logo text', () => {
       render(<LandingNav />);
 
-      const logo = screen.getByText('CHAGOK');
+      const logo = screen.getByText(BRAND.name);
       expect(logo).toHaveClass('text-secondary');
     });
   });

--- a/frontend/src/components/landing/__tests__/SolutionSection.test.tsx
+++ b/frontend/src/components/landing/__tests__/SolutionSection.test.tsx
@@ -3,7 +3,7 @@
  * Plan 3.19.1 - Solution (3가지 핵심 기능)
  *
  * Requirements:
- * - Section title: "Legal Evidence Hub가 해결합니다"
+ * - Section title: "{BRAND.name}이 해결합니다"
  * - 3-column layout with core features:
  *   1. 자동 증거 분석: 이미지/음성/PDF를 AI가 자동 분류 및 요약
  *   2. 스마트 타임라인: 시간순 증거 정리, 유책사유 자동 태깅
@@ -14,27 +14,28 @@
 
 import { render, screen } from '@testing-library/react';
 import SolutionSection from '../SolutionSection';
+import { BRAND } from '@/config/brand';
 
 describe('SolutionSection Component', () => {
   describe('Section Title', () => {
     it('should render the section title', () => {
       render(<SolutionSection />);
 
-      const title = screen.getByRole('heading', { name: /legal evidence hub가 해결합니다/i });
+      const title = screen.getByRole('heading', { name: new RegExp(`${BRAND.name}이 해결합니다`, 'i') });
       expect(title).toBeInTheDocument();
     });
 
     it('should style title with Deep Trust Blue', () => {
       render(<SolutionSection />);
 
-      const title = screen.getByRole('heading', { name: /legal evidence hub가 해결합니다/i });
+      const title = screen.getByRole('heading', { name: new RegExp(`${BRAND.name}이 해결합니다`, 'i') });
       expect(title).toHaveClass('text-secondary');
     });
 
     it('should use appropriate heading level (h2)', () => {
       render(<SolutionSection />);
 
-      const title = screen.getByRole('heading', { name: /legal evidence hub가 해결합니다/i });
+      const title = screen.getByRole('heading', { name: new RegExp(`${BRAND.name}이 해결합니다`, 'i') });
       expect(title.tagName).toBe('H2');
     });
   });
@@ -267,7 +268,7 @@ describe('SolutionSection Component', () => {
     it('should have proper heading hierarchy', () => {
       render(<SolutionSection />);
 
-      const mainHeading = screen.getByRole('heading', { name: /legal evidence hub가 해결합니다/i });
+      const mainHeading = screen.getByRole('heading', { name: new RegExp(`${BRAND.name}이 해결합니다`, 'i') });
       expect(mainHeading.tagName).toBe('H2');
 
       const featureHeadings = screen.getAllByRole('heading', { level: 3 });

--- a/frontend/src/components/lawyer/LawyerNav.tsx
+++ b/frontend/src/components/lawyer/LawyerNav.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useRole } from '@/hooks/useRole';
 import { NotificationDropdown } from '@/components/shared/NotificationDropdown';
+import { BRAND } from '@/config/brand';
 
 interface NavItem {
   label: string;
@@ -120,10 +121,10 @@ export function LawyerNav({ collapsed = false, onItemClick }: LawyerNavProps) {
       <div className="p-4 border-b border-gray-200 dark:border-neutral-700">
         <Link href="/lawyer/dashboard" className="flex items-center gap-2">
           <div className="w-8 h-8 bg-[var(--color-primary)] rounded-lg flex items-center justify-center">
-            <span className="text-white font-bold text-sm">LEH</span>
+            <span className="text-white font-bold text-sm">{BRAND.nameKo}</span>
           </div>
           {!collapsed && (
-            <span className="font-semibold text-gray-900 dark:text-gray-100">Legal Evidence Hub</span>
+            <span className="font-semibold text-gray-900 dark:text-gray-100">{BRAND.name}</span>
           )}
         </Link>
       </div>

--- a/frontend/src/components/portal/ClientUploadCard.tsx
+++ b/frontend/src/components/portal/ClientUploadCard.tsx
@@ -1,5 +1,6 @@
 import { UploadCloud, ShieldCheck, Loader2 } from 'lucide-react';
 import clsx from 'clsx';
+import { BRAND } from '@/config/brand';
 
 type UploadStatus = 'idle' | 'uploading' | 'success' | 'error';
 
@@ -44,7 +45,7 @@ export default function ClientUploadCard({ status, uploadedCount, uploadedFiles,
         <div className="w-full max-w-2xl bg-white border border-gray-100 shadow-xl rounded-3xl p-10 space-y-8">
             <header className="text-center space-y-3">
                 <div className="inline-flex items-center justify-center px-4 py-1 rounded-full bg-primary/10 text-primary text-xs font-semibold tracking-[0.25em] uppercase">
-                    Legal Evidence Hub
+                    {BRAND.name}
                 </div>
                 <div>
                     <h1 className="text-2xl font-bold text-secondary">의뢰인 증거 제출 포털</h1>

--- a/frontend/src/components/shared/Logo.tsx
+++ b/frontend/src/components/shared/Logo.tsx
@@ -6,6 +6,8 @@
  * Design: "Neatly Stacked" concept - 3 floating document sheets
  */
 
+import { BRAND } from '@/config/brand';
+
 interface LogoProps {
   /** Size preset or custom pixel value */
   size?: 'sm' | 'md' | 'lg' | number;
@@ -101,7 +103,7 @@ export function Logo({ size = 'md', variant = 'icon', className = '' }: LogoProp
 
   if (variant === 'icon') {
     return (
-      <div className={className} role="img" aria-label="CHAGOK 로고">
+      <div className={className} role="img" aria-label={`${BRAND.name} 로고`}>
         <LogoIcon size={pixelSize} />
       </div>
     );
@@ -109,13 +111,13 @@ export function Logo({ size = 'md', variant = 'icon', className = '' }: LogoProp
 
   // Full variant: icon + text
   return (
-    <div className={`flex items-center gap-2 ${className}`} role="img" aria-label="CHAGOK 로고">
+    <div className={`flex items-center gap-2 ${className}`} role="img" aria-label={`${BRAND.name} 로고`}>
       <LogoIcon size={pixelSize} />
       <span
         className="font-bold text-secondary"
         style={{ fontSize: `${Math.max(pixelSize * 0.5, 14)}px` }}
       >
-        CHAGOK
+        {BRAND.name}
       </span>
     </div>
   );

--- a/frontend/src/config/brand.ts
+++ b/frontend/src/config/brand.ts
@@ -1,0 +1,27 @@
+/**
+ * Brand Configuration
+ * Centralized brand naming for the application.
+ *
+ * Values are loaded from environment variables with fallbacks.
+ * Update .env to customize brand naming without code changes.
+ */
+
+export const BRAND = {
+  /** Primary brand name (e.g., "CHAGOK") */
+  name: process.env.NEXT_PUBLIC_BRAND_NAME || 'CHAGOK',
+
+  /** Korean brand name (e.g., "차곡") */
+  nameKo: process.env.NEXT_PUBLIC_BRAND_NAME_KO || '차곡',
+
+  /** Full brand name with Korean (e.g., "CHAGOK (차곡)") */
+  fullName: process.env.NEXT_PUBLIC_BRAND_FULL_NAME || 'CHAGOK (차곡)',
+
+  /** Brand description */
+  description: process.env.NEXT_PUBLIC_BRAND_DESCRIPTION || 'AI 기반 법률 증거 관리 시스템',
+
+  /** Default law firm name for portals */
+  defaultFirmName: `${process.env.NEXT_PUBLIC_BRAND_NAME || 'CHAGOK'} 법률사무소`,
+} as const;
+
+export type Brand = typeof BRAND;
+export default BRAND;


### PR DESCRIPTION
## Summary
- 브랜드 설정(로고, 회사명 등)을 환경변수로 중앙 관리하도록 변경
- `frontend/src/config/brand.ts`에서 모든 브랜드 정보 통합 관리
- 23개 파일에서 하드코딩된 브랜드 값을 config 참조로 변경

## Changes
- `config/brand.ts` 신규 생성: 환경변수 기반 브랜드 설정
- Logo, Footer, Nav, HeroSection 등 컴포넌트에서 brand config 사용
- 관련 테스트 파일 업데이트

## Test plan
- [x] 빌드 성공 확인
- [ ] Staging 배포 후 로고/브랜드명 변경 확인