### PR TITLE
fix(backend): 유사 판례 검색 동적 유책사유 추출 구현

### DIFF
--- a/backend/app/services/precedent_service.py
+++ b/backend/app/services/precedent_service.py
@@ -19,8 +19,22 @@ from app.utils.precedent_search import (
     search_similar_precedents as qdrant_search,
     get_fallback_precedents,
 )
+from app.utils.dynamo import get_evidence_by_case
 
 logger = logging.getLogger(__name__)
+
+# Article 840 카테고리 → 한글 레이블 매핑
+CATEGORY_KO_MAP = {
+    "adultery": "부정행위",
+    "desertion": "악의의 유기",
+    "mistreatment_by_inlaws": "시댁 부당대우",
+    "harm_to_own_parents": "친부모 해악",
+    "unknown_whereabouts": "생사불명",
+    "irreconcilable_differences": "혼인지속 곤란",
+    "domestic_violence": "가정폭력",
+    "financial_misconduct": "재정 비행",
+    "general": "일반",
+}
 
 
 class PrecedentService:
@@ -46,8 +60,11 @@ class PrecedentService:
         Returns:
             PrecedentSearchResponse: 판례 목록 및 쿼리 컨텍스트
         """
+        logger.info(f"[PrecedentSearch] Starting search for case_id={case_id}")
+
         # T021: 사건의 유책사유 추출
         fault_types = self.get_fault_types(case_id)
+        logger.info(f"[PrecedentSearch] Extracted fault_types={fault_types}")
 
         if not fault_types:
             # 유책사유가 없으면 기본 검색어 사용
@@ -56,14 +73,18 @@ class PrecedentService:
             # 유책사유를 검색 쿼리로 변환
             query = " ".join(fault_types)
 
+        logger.info(f"[PrecedentSearch] Search query: {query}")
+        using_fallback = False
+
         try:
             # Qdrant 검색 실행
             raw_results = qdrant_search(query, limit=limit, min_score=min_score)
 
             if not raw_results:
-                # T024: Fallback 데이터 사용
-                logger.warning(f"No Qdrant results for case {case_id}, using fallback")
-                raw_results = get_fallback_precedents()
+                # T024: Fallback 데이터 사용 (fault_types 기반 필터링)
+                logger.warning(f"No Qdrant results for case {case_id}, using fallback with fault_types={fault_types}")
+                raw_results = get_fallback_precedents(fault_types)
+                using_fallback = True
 
             # 결과를 PrecedentCase 스키마로 변환
             precedents = []
@@ -87,6 +108,8 @@ class PrecedentService:
                 )
                 precedents.append(precedent)
 
+            logger.info(f"[PrecedentSearch] Results: {len(precedents)} precedents, using_fallback={using_fallback}")
+
             return PrecedentSearchResponse(
                 precedents=precedents,
                 query_context=QueryContext(
@@ -96,7 +119,7 @@ class PrecedentService:
             )
 
         except Exception as e:
-            logger.error(f"Precedent search error for case {case_id}: {e}")
+            logger.error(f"[PrecedentSearch] Error for case {case_id}: {e}")
             # 오류 시 Fallback 데이터 반환
             return self._get_fallback_response(fault_types)
 
@@ -104,19 +127,52 @@ class PrecedentService:
         """
         사건의 유책사유 추출 (T021)
 
-        DynamoDB 또는 PostgreSQL에서 사건의 유책사유 레이블을 조회합니다.
+        DynamoDB evidence 테이블에서 article_840_tags.categories 조회
         """
         try:
-            # TODO: 실제 구현에서는 DynamoDB evidence 테이블에서 labels 조회
-            # 현재는 샘플 데이터 반환
-            return ["부정행위", "별거"]
+            # DynamoDB에서 해당 케이스의 증거 목록 조회
+            evidences = get_evidence_by_case(case_id)
+
+            if not evidences:
+                logger.info(f"No evidence found for case {case_id}, using default query")
+                return []
+
+            # 각 증거의 article_840_tags.categories 수집
+            fault_types = set()
+            for evidence in evidences:
+                # article_840_tags에서 categories 추출
+                tags = evidence.get("article_840_tags")
+                if tags and isinstance(tags, dict):
+                    categories = tags.get("categories", [])
+                    for cat in categories:
+                        # 문자열인 경우 그대로 사용
+                        if isinstance(cat, str):
+                            fault_types.add(cat)
+
+                # labels 필드에서도 추출 (백업)
+                labels = evidence.get("labels")
+                if labels and isinstance(labels, list):
+                    for label in labels:
+                        if isinstance(label, str) and label not in ["general", "일반"]:
+                            fault_types.add(label)
+
+            # 한글 레이블로 변환
+            korean_labels = []
+            for cat in fault_types:
+                korean_label = CATEGORY_KO_MAP.get(cat, cat)
+                if korean_label and korean_label not in ["일반", "general"]:
+                    korean_labels.append(korean_label)
+
+            logger.info(f"Case {case_id}: extracted fault_types={korean_labels} from {len(evidences)} evidences")
+            return korean_labels if korean_labels else []
+
         except Exception as e:
             logger.error(f"Failed to get fault types for case {case_id}: {e}")
             return []
 
     def _get_fallback_response(self, fault_types: List[str]) -> PrecedentSearchResponse:
-        """T024: Fallback 응답 생성"""
-        fallback_data = get_fallback_precedents()
+        """T024: Fallback 응답 생성 (fault_types 기반 필터링)"""
+        fallback_data = get_fallback_precedents(fault_types)
 
         precedents = []
         for item in fallback_data:


### PR DESCRIPTION
## Summary
- 하드코딩된 `get_fault_types()` 메서드를 DynamoDB 연동으로 변경
- 케이스별 실제 증거 데이터에서 `article_840_tags.categories` 추출
- Fallback 판례 8개로 확장 및 유책사유 기반 필터링 추가

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `precedent_service.py` | DynamoDB 연동, CATEGORY_KO_MAP 추가, 로깅 강화 |
| `precedent_search.py` | Fallback 8개 Mock, fault_types 기반 필터링 |

## Problem
- 유사 판례 검색 시 모든 케이스에서 항상 같은 3개 판례만 반환됨
- 원인: `get_fault_types()`가 항상 `["부정행위", "별거"]` 하드코딩 반환

## Solution
1. DynamoDB에서 케이스 증거 조회 (`get_evidence_by_case`)
2. `article_840_tags.categories` 추출
3. CATEGORY_KO_MAP으로 한글 변환
4. Fallback도 유책사유 기반 필터링

## Test plan
- [x] 로컬 pytest 전체 통과 (16/16 precedent 테스트)
- [ ] Staging 배포 후 다른 케이스에서 다른 판례 반환 확인
- [ ] DynamoDB에 증거가 있는 케이스 테스트
- [ ] DynamoDB에 증거가 없는 케이스 (기본 쿼리) 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)