### PR TITLE
fix(precedent): Add Article 840 fullname mapping for AI Worker categories

### DIFF
--- a/backend/app/services/precedent_service.py
+++ b/backend/app/services/precedent_service.py
@@ -36,6 +36,41 @@ CATEGORY_KO_MAP = {
     "general": "일반",
 }
 
+# AI Worker가 저장하는 한글 풀네임 → 짧은 키워드 매핑
+# (민법 제840조 이혼사유)
+ARTICLE_840_FULLNAME_MAP = {
+    # 1호: 배우자에 부정한 행위가 있었을 때
+    "1호_부정행위": "부정행위",
+    "1호_배우자의 부정행위": "부정행위",
+    # 2호: 배우자가 악의로 다른 일방을 유기한 때
+    "2호_악의의 유기": "악의의 유기",
+    "2호_배우자의 악의적 유기": "악의의 유기",
+    # 3호: 배우자 또는 그 직계존속으로부터 심히 부당한 대우를 받았을 때
+    "3호_배우자 또는 그 직계존속으로부터의 폭언": "가정폭력",
+    "3호_배우자 또는 그 직계존속으로부터 심히 부당한 대우": "가정폭력",
+    "3호_시댁 부당대우": "시댁 부당대우",
+    # 4호: 자기의 직계존속이 배우자로부터 심히 부당한 대우를 받았을 때
+    "4호_친부모에 대한 부당대우": "친부모 해악",
+    "4호_직계존속에 대한 부당대우": "친부모 해악",
+    # 5호: 배우자의 생사가 3년 이상 분명하지 아니한 때
+    "5호_생사불명": "생사불명",
+    "5호_배우자 생사불명 3년 이상": "생사불명",
+    # 6호: 기타 혼인을 계속하기 어려운 중대한 사유가 있을 때
+    "5호_기타 혼인을 계속하기 어려운 중대한 사유": "혼인지속 곤란",
+    "6호_기타 혼인을 계속하기 어려운 중대한 사유": "혼인지속 곤란",
+    "6호_혼인지속 곤란": "혼인지속 곤란",
+    # 기타 자주 나오는 패턴
+    "가정폭력": "가정폭력",
+    "폭언": "가정폭력",
+    "폭행": "가정폭력",
+    "부정행위": "부정행위",
+    "외도": "부정행위",
+    "불륜": "부정행위",
+    "재정 비행": "재정 비행",
+    "도박": "재정 비행",
+    "채무": "재정 비행",
+}
+
 
 class PrecedentService:
     """판례 검색 서비스 (T019)"""
@@ -156,15 +191,24 @@ class PrecedentService:
                         if isinstance(label, str) and label not in ["general", "일반"]:
                             fault_types.add(label)
 
-            # 한글 레이블로 변환
-            korean_labels = []
+            # 한글 레이블로 변환 (풀네임 → 짧은 키워드 → 최종 레이블)
+            korean_labels = set()
             for cat in fault_types:
-                korean_label = CATEGORY_KO_MAP.get(cat, cat)
-                if korean_label and korean_label not in ["일반", "general"]:
-                    korean_labels.append(korean_label)
+                # 1차: AI Worker 풀네임 매핑 시도
+                if cat in ARTICLE_840_FULLNAME_MAP:
+                    korean_labels.add(ARTICLE_840_FULLNAME_MAP[cat])
+                # 2차: 영문 키 → 한글 레이블 매핑 시도
+                elif cat in CATEGORY_KO_MAP:
+                    label = CATEGORY_KO_MAP[cat]
+                    if label not in ["일반", "general"]:
+                        korean_labels.add(label)
+                # 3차: 그대로 사용 (이미 짧은 한글인 경우)
+                elif cat not in ["일반", "general"]:
+                    korean_labels.add(cat)
 
-            logger.info(f"Case {case_id}: extracted fault_types={korean_labels} from {len(evidences)} evidences")
-            return korean_labels if korean_labels else []
+            result = list(korean_labels)
+            logger.info(f"Case {case_id}: extracted fault_types={result} from {len(evidences)} evidences")
+            return result
 
         except Exception as e:
             logger.error(f"Failed to get fault types for case {case_id}: {e}")


### PR DESCRIPTION
## Summary
- AI Worker가 저장하는 한글 풀네임 카테고리를 짧은 키워드로 매핑하는 `ARTICLE_840_FULLNAME_MAP` 추가
- `get_fault_types()`에서 3단계 변환 로직 적용 (풀네임 → 영문키 → 패스스루)
- 포맷 불일치로 인해 항상 기본 fallback 판례만 반환되던 문제 수정

## Problem
AI Worker는 `"3호_배우자 또는 그 직계존속으로부터의 폭언"` 형태로 저장하지만,
fallback 판례의 `key_factors`는 `["가정폭력"]` 같은 짧은 키워드를 사용.
→ 매칭 실패 → 항상 기본 3개 판례만 반환

## Solution
`ARTICLE_840_FULLNAME_MAP`으로 풀네임을 짧은 키워드로 변환하여 정확한 판례 매칭 가능

## Test plan
- [ ] 증거에 `3호_배우자 또는 그 직계존속으로부터의 폭언` 태그가 있는 케이스에서 유사 판례 검색
- [ ] 가정폭력 관련 판례(2019므98765, 2020므22222)가 반환되는지 확인