### PR TITLE
refactor(frontend): 사이드바 네비게이션 NavGroup 인터페이스 적용

### DIFF
--- a/frontend/src/app/client/layout.tsx
+++ b/frontend/src/app/client/layout.tsx
@@ -3,46 +3,54 @@
 /**
  * Client Portal Layout
  * 003-role-based-ui Feature
+ * Updated: navbar-sidebar-refactoring
  *
  * Layout for the client portal with simplified navigation.
- * Responsive design with mobile drawer.
- * Uses design system tokens.
+ * Uses PortalSidebar with NavGroup for hierarchical navigation.
  */
 
-import { useState } from 'react';
-import PortalSidebar, { NavIcons, NavItem, HamburgerIcon } from '@/components/shared/PortalSidebar';
+import { PortalSidebar, NavGroup } from '@/components/shared/PortalSidebar';
 import RoleGuard from '@/components/auth/RoleGuard';
 import { useAuth } from '@/hooks/useAuth';
 import { useRole } from '@/hooks/useRole';
 import { UserRole } from '@/types/user';
-import { logger } from '@/lib/logger';
+import {
+  LayoutDashboard,
+  Briefcase,
+  MessageSquare,
+  CreditCard,
+} from 'lucide-react';
 
-// Client navigation items - simplified view
-const clientNavItems: NavItem[] = [
+// Client navigation groups - simplified view
+const clientNavGroups: NavGroup[] = [
   {
-    id: 'dashboard',
-    label: '내 현황',
-    href: '/client/dashboard',
-    icon: <NavIcons.Dashboard />,
-  },
-  {
-    id: 'cases',
-    label: '케이스 상태',
-    href: '/client/cases',
-    icon: <NavIcons.Cases />,
-  },
-  {
-    id: 'messages',
-    label: '변호사 소통',
-    href: '/client/messages',
-    icon: <NavIcons.Messages />,
-    badge: 0,
-  },
-  {
-    id: 'billing',
-    label: '청구/결제',
-    href: '/client/billing',
-    icon: <NavIcons.Billing />,
+    id: 'main',
+    items: [
+      {
+        id: 'dashboard',
+        label: '내 현황',
+        href: '/client/dashboard',
+        icon: <LayoutDashboard className="w-5 h-5" />,
+      },
+      {
+        id: 'cases',
+        label: '케이스 상태',
+        href: '/client/cases',
+        icon: <Briefcase className="w-5 h-5" />,
+      },
+      {
+        id: 'messages',
+        label: '변호사 소통',
+        href: '/client/messages',
+        icon: <MessageSquare className="w-5 h-5" />,
+      },
+      {
+        id: 'billing',
+        label: '청구/결제',
+        href: '/client/billing',
+        icon: <CreditCard className="w-5 h-5" />,
+      },
+    ],
   },
 ];
 
@@ -54,17 +62,8 @@ export default function ClientLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const { role } = useRole();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  const handleLogout = async () => {
-    try {
-      await logout();
-    } catch (error) {
-      logger.error('Logout failed', error);
-    }
-  };
 
   const renderContent = () => {
     if (!user || !role) {
@@ -77,57 +76,20 @@ export default function ClientLayout({
 
     return (
       <div className="flex min-h-screen bg-[var(--color-bg-secondary)]">
-      {/* Sidebar */}
-      <PortalSidebar
-        role={user.role}
-        userName={user.name}
-        userEmail={user.email}
-        navItems={clientNavItems}
-        onLogout={handleLogout}
-        isOpen={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
-      />
+        {/* Sidebar */}
+        <PortalSidebar groups={clientNavGroups} />
 
-      {/* Main Content */}
-      <main className="flex-1 lg:ml-64 min-h-screen">
-        {/* Top Header */}
-        <header className="sticky top-0 z-10 h-16 bg-white border-b border-[var(--color-border-default)] flex items-center px-4 lg:px-6">
-          {/* Mobile menu button */}
-          <button
-            onClick={() => setSidebarOpen(true)}
-            className="lg:hidden p-2 rounded-lg hover:bg-[var(--color-bg-secondary)] transition-colors mr-2"
-            aria-label="메뉴 열기"
-          >
-            <HamburgerIcon />
-          </button>
+        {/* Main Content */}
+        <main className="flex-1 lg:ml-64 min-h-screen">
+          {/* Mobile header spacing */}
+          <div className="h-16 lg:hidden" />
 
-          <div className="flex-1" />
-          <div className="flex items-center gap-2 sm:gap-4">
-            {/* Notification bell */}
-            <button
-              className="relative p-2 rounded-lg hover:bg-[var(--color-bg-secondary)] transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
-              aria-label="알림"
-            >
-              <svg className="w-5 h-5 text-[var(--color-text-secondary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-              </svg>
-            </button>
-
-            {/* User menu */}
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-[var(--color-primary)] flex items-center justify-center text-white font-semibold text-sm">
-                {user.name.slice(0, 2).toUpperCase()}
-              </div>
-            </div>
+          {/* Page Content */}
+          <div className="p-4 lg:p-6">
+            {children}
           </div>
-        </header>
-
-        {/* Page Content */}
-        <div className="p-4 lg:p-6">
-          {children}
-        </div>
-      </main>
-    </div>
+        </main>
+      </div>
     );
   };
 

--- a/frontend/src/app/detective/layout.tsx
+++ b/frontend/src/app/detective/layout.tsx
@@ -3,51 +3,54 @@
 /**
  * Detective Portal Layout
  * 003-role-based-ui Feature
+ * Updated: navbar-sidebar-refactoring
  *
  * Layout for the detective portal with field investigation tools.
- * Responsive design with mobile drawer.
- * Uses design system tokens.
+ * Uses PortalSidebar with NavGroup for hierarchical navigation.
  */
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import PortalSidebar, { NavIcons, NavItem, HamburgerIcon } from '@/components/shared/PortalSidebar';
+import { PortalSidebar, NavGroup } from '@/components/shared/PortalSidebar';
 import RoleGuard from '@/components/auth/RoleGuard';
 import { useAuth } from '@/hooks/useAuth';
 import { useRole } from '@/hooks/useRole';
 import { UserRole } from '@/types/user';
-import { logger } from '@/lib/logger';
+import {
+  LayoutDashboard,
+  Briefcase,
+  MessageSquare,
+  Wallet,
+} from 'lucide-react';
 
-// Detective navigation items
-const detectiveNavItems: NavItem[] = [
+// Detective navigation groups
+const detectiveNavGroups: NavGroup[] = [
   {
-    id: 'dashboard',
-    label: '대시보드',
-    href: '/detective/dashboard',
-    icon: <NavIcons.Dashboard />,
-  },
-  {
-    id: 'cases',
-    label: '의뢰 관리',
-    href: '/detective/cases',
-    icon: <NavIcons.Cases />,
-  },
-  {
-    id: 'messages',
-    label: '메시지',
-    href: '/detective/messages',
-    icon: <NavIcons.Messages />,
-    badge: 0,
-  },
-  {
-    id: 'earnings',
-    label: '정산/수익',
-    href: '/detective/earnings',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-      </svg>
-    ),
+    id: 'main',
+    items: [
+      {
+        id: 'dashboard',
+        label: '대시보드',
+        href: '/detective/dashboard',
+        icon: <LayoutDashboard className="w-5 h-5" />,
+      },
+      {
+        id: 'cases',
+        label: '의뢰 관리',
+        href: '/detective/cases',
+        icon: <Briefcase className="w-5 h-5" />,
+      },
+      {
+        id: 'messages',
+        label: '메시지',
+        href: '/detective/messages',
+        icon: <MessageSquare className="w-5 h-5" />,
+      },
+      {
+        id: 'earnings',
+        label: '정산/수익',
+        href: '/detective/earnings',
+        icon: <Wallet className="w-5 h-5" />,
+      },
+    ],
   },
 ];
 
@@ -59,18 +62,8 @@ export default function DetectiveLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const router = useRouter();
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const { role } = useRole();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  const handleLogout = async () => {
-    try {
-      await logout();
-    } catch (error) {
-      logger.error('Logout failed', error);
-    }
-  };
 
   const renderContent = () => {
     if (!user || !role) {
@@ -83,57 +76,20 @@ export default function DetectiveLayout({
 
     return (
       <div className="flex min-h-screen bg-[var(--color-bg-secondary)]">
-      {/* Sidebar */}
-      <PortalSidebar
-        role={user.role}
-        userName={user.name}
-        userEmail={user.email}
-        navItems={detectiveNavItems}
-        onLogout={handleLogout}
-        isOpen={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
-      />
+        {/* Sidebar */}
+        <PortalSidebar groups={detectiveNavGroups} />
 
-      {/* Main Content */}
-      <main className="flex-1 lg:ml-64 min-h-screen">
-        {/* Top Header */}
-        <header className="sticky top-0 z-10 h-16 bg-white border-b border-[var(--color-border-default)] flex items-center px-4 lg:px-6">
-          {/* Mobile menu button */}
-          <button
-            onClick={() => setSidebarOpen(true)}
-            className="lg:hidden p-2 rounded-lg hover:bg-[var(--color-bg-secondary)] transition-colors mr-2"
-            aria-label="메뉴 열기"
-          >
-            <HamburgerIcon />
-          </button>
+        {/* Main Content */}
+        <main className="flex-1 lg:ml-64 min-h-screen">
+          {/* Mobile header spacing */}
+          <div className="h-16 lg:hidden" />
 
-          <div className="flex-1" />
-          <div className="flex items-center gap-2 sm:gap-4">
-            {/* Notification bell */}
-            <button
-              className="relative p-2 rounded-lg hover:bg-[var(--color-bg-secondary)] transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
-              aria-label="알림"
-            >
-              <svg className="w-5 h-5 text-[var(--color-text-secondary)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-              </svg>
-            </button>
-
-            {/* User menu */}
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-[var(--color-primary)] flex items-center justify-center text-white font-semibold text-sm">
-                {user.name.slice(0, 2).toUpperCase()}
-              </div>
-            </div>
+          {/* Page Content */}
+          <div className="p-4 lg:p-6">
+            {children}
           </div>
-        </header>
-
-        {/* Page Content */}
-        <div className="p-4 lg:p-6">
-          {children}
-        </div>
-      </main>
-    </div>
+        </main>
+      </div>
     );
   };
 

--- a/frontend/src/app/lawyer/layout.tsx
+++ b/frontend/src/app/lawyer/layout.tsx
@@ -3,73 +3,103 @@
 /**
  * Lawyer Portal Layout
  * 003-role-based-ui Feature
+ * Updated: navbar-sidebar-refactoring
  *
  * Layout for the lawyer portal with sidebar navigation.
- * Responsive design with mobile drawer.
- * Uses design system tokens.
+ * Uses PortalSidebar with NavGroup for hierarchical navigation.
  */
 
-import { useState } from 'react';
-import PortalSidebar, { NavIcons, NavItem, HamburgerIcon } from '@/components/shared/PortalSidebar';
-import { NotificationDropdown } from '@/components/shared/NotificationDropdown';
+import { PortalSidebar, NavGroup } from '@/components/shared/PortalSidebar';
 import RoleGuard from '@/components/auth/RoleGuard';
 import { useAuth } from '@/hooks/useAuth';
 import { useRole } from '@/hooks/useRole';
 import { UserRole } from '@/types/user';
-import { logger } from '@/lib/logger';
+import {
+  LayoutDashboard,
+  Briefcase,
+  Users,
+  Search,
+  Calendar,
+  MessageSquare,
+  CreditCard,
+  Upload,
+  FileText,
+} from 'lucide-react';
 
-// Lawyer navigation items
-const lawyerNavItems: NavItem[] = [
+// Lawyer navigation groups with hierarchical structure
+const lawyerNavGroups: NavGroup[] = [
   {
-    id: 'dashboard',
-    label: '대시보드',
-    href: '/lawyer/dashboard',
-    icon: <NavIcons.Dashboard />,
+    id: 'core',
+    items: [
+      {
+        id: 'dashboard',
+        label: '대시보드',
+        href: '/lawyer/dashboard',
+        icon: <LayoutDashboard className="w-5 h-5" />,
+      },
+      {
+        id: 'cases',
+        label: '케이스',
+        href: '/lawyer/cases',
+        icon: <Briefcase className="w-5 h-5" />,
+      },
+    ],
   },
   {
-    id: 'cases',
-    label: '케이스 관리',
-    href: '/lawyer/cases',
-    icon: <NavIcons.Cases />,
+    id: 'work',
+    label: '작업',
+    collapsible: true,
+    items: [
+      {
+        id: 'evidence-upload',
+        label: '증거 업로드',
+        href: '/lawyer/evidence/upload',
+        icon: <Upload className="w-5 h-5" />,
+      },
+      {
+        id: 'drafts',
+        label: '초안 생성',
+        href: '/lawyer/drafts',
+        icon: <FileText className="w-5 h-5" />,
+      },
+    ],
   },
   {
-    id: 'clients',
-    label: '의뢰인 관리',
-    href: '/lawyer/clients',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-      </svg>
-    ),
-  },
-  {
-    id: 'investigators',
-    label: '탐정/조사원',
-    href: '/lawyer/investigators',
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-      </svg>
-    ),
-  },
-  {
-    id: 'calendar',
-    label: '일정 관리',
-    href: '/lawyer/calendar',
-    icon: <NavIcons.Calendar />,
-  },
-  {
-    id: 'messages',
-    label: '메시지',
-    href: '/lawyer/messages',
-    icon: <NavIcons.Messages />,
-    badge: 0, // Will be updated with unread count
-  },
-  {
-    id: 'billing',
-    label: '청구/정산',
-    href: '/lawyer/billing',
-    icon: <NavIcons.Billing />,
+    id: 'management',
+    label: '관리',
+    collapsible: true,
+    items: [
+      {
+        id: 'clients',
+        label: '의뢰인',
+        href: '/lawyer/clients',
+        icon: <Users className="w-5 h-5" />,
+      },
+      {
+        id: 'investigators',
+        label: '탐정',
+        href: '/lawyer/investigators',
+        icon: <Search className="w-5 h-5" />,
+      },
+      {
+        id: 'calendar',
+        label: '일정',
+        href: '/lawyer/calendar',
+        icon: <Calendar className="w-5 h-5" />,
+      },
+      {
+        id: 'messages',
+        label: '메시지',
+        href: '/lawyer/messages',
+        icon: <MessageSquare className="w-5 h-5" />,
+      },
+      {
+        id: 'billing',
+        label: '청구/결제',
+        href: '/lawyer/billing',
+        icon: <CreditCard className="w-5 h-5" />,
+      },
+    ],
   },
 ];
 
@@ -80,17 +110,8 @@ export default function LawyerLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const { role } = useRole();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  const handleLogout = async () => {
-    try {
-      await logout();
-    } catch (error) {
-      logger.error('Logout failed', error);
-    }
-  };
 
   const renderContent = () => {
     if (!user || !role) {
@@ -103,52 +124,20 @@ export default function LawyerLayout({
 
     return (
       <div className="flex min-h-screen bg-[var(--color-bg-secondary)]">
-      {/* Sidebar */}
-      <PortalSidebar
-        role={user.role}
-        userName={user.name}
-        userEmail={user.email}
-        navItems={lawyerNavItems}
-        onLogout={handleLogout}
-        isOpen={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
-      />
+        {/* Sidebar */}
+        <PortalSidebar groups={lawyerNavGroups} />
 
-      {/* Main Content */}
-      <main className="flex-1 lg:ml-64 min-h-screen">
-        {/* Top Header */}
-        <header className="sticky top-0 z-10 h-16 bg-[var(--color-bg-primary)] border-b border-[var(--color-border-default)] flex items-center px-4 lg:px-6">
-          {/* Mobile menu button */}
-          <button
-            onClick={() => setSidebarOpen(true)}
-            className="lg:hidden p-2 rounded-lg hover:bg-[var(--color-bg-secondary)] transition-colors mr-2"
-            aria-label="메뉴 열기"
-          >
-            <HamburgerIcon />
-          </button>
+        {/* Main Content */}
+        <main className="flex-1 lg:ml-64 min-h-screen">
+          {/* Mobile header spacing */}
+          <div className="h-16 lg:hidden" />
 
-          <div className="flex-1">
-            {/* Breadcrumb or page title can go here */}
+          {/* Page Content */}
+          <div className="p-4 lg:p-6">
+            {children}
           </div>
-          <div className="flex items-center gap-2 sm:gap-4">
-            {/* Notification dropdown */}
-            <NotificationDropdown />
-
-            {/* User menu */}
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-[var(--color-primary)] flex items-center justify-center text-[var(--color-primary-contrast)] font-semibold text-sm">
-                {user.name.slice(0, 2).toUpperCase()}
-              </div>
-            </div>
-          </div>
-        </header>
-
-        {/* Page Content */}
-        <div className="p-4 lg:p-6">
-          {children}
-        </div>
-      </main>
-    </div>
+        </main>
+      </div>
     );
   };
 

--- a/frontend/src/components/shared/PortalSidebar.tsx
+++ b/frontend/src/components/shared/PortalSidebar.tsx
@@ -1,19 +1,19 @@
 'use client';
 
 /**
- * Portal Sidebar Component
- * 003-role-based-ui Feature
- *
- * Shared sidebar navigation for all role-based portals.
- * Supports responsive design with mobile drawer.
- * Uses design system tokens.
+ * PortalSidebar Component
+ * Navigation sidebar with section grouping support
  */
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect } from 'react';
-import { UserRole, ROLE_DISPLAY_NAMES } from '@/types/user';
-import { Logo } from '@/components/shared/Logo';
+import { Menu, X, LogOut, ChevronDown, ChevronRight } from 'lucide-react';
+import { Logo } from './Logo';
+import { NotificationDropdown } from './NotificationDropdown';
+import { useAuth } from '@/hooks/useAuth';
+import { useRole } from '@/hooks/useRole';
+import { ROLE_DISPLAY_NAMES } from '@/types/user';
 
 export interface NavItem {
   id: string;
@@ -23,237 +23,232 @@ export interface NavItem {
   badge?: number;
 }
 
-interface PortalSidebarProps {
-  role: UserRole;
-  userName: string;
-  userEmail: string;
-  navItems: NavItem[];
-  onLogout: () => void;
-  isOpen?: boolean;
-  onClose?: () => void;
-  /** Home link destination (defaults to role-specific dashboard) */
-  homeHref?: string;
+export interface NavGroup {
+  id: string;
+  label?: string;
+  items: NavItem[];
+  collapsible?: boolean;
 }
 
-// Close icon for mobile drawer
-const CloseIcon = () => (
-  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-  </svg>
-);
-
-// Icons as simple SVG components
-const DashboardIcon = () => (
-  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-  </svg>
-);
-
-const CasesIcon = () => (
-  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
-  </svg>
-);
-
-const CalendarIcon = () => (
-  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-  </svg>
-);
-
-const MessagesIcon = () => (
-  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-  </svg>
-);
-
-const BillingIcon = () => (
-  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
-  </svg>
-);
-
-const SettingsIcon = () => (
-  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-  </svg>
-);
-
-const LogoutIcon = () => (
-  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-  </svg>
-);
-
-// Export icons for reuse
-export const NavIcons = {
-  Dashboard: DashboardIcon,
-  Cases: CasesIcon,
-  Calendar: CalendarIcon,
-  Messages: MessagesIcon,
-  Billing: BillingIcon,
-  Settings: SettingsIcon,
-  Logout: LogoutIcon,
-};
-
-// T073 - FR-028: Role-specific home destinations
-const ROLE_HOME_PATHS: Record<UserRole, string> = {
-  lawyer: '/lawyer/dashboard',
-  client: '/client/dashboard',
-  detective: '/detective/dashboard',
-  admin: '/admin/dashboard',
-  staff: '/staff/dashboard',
-};
+interface PortalSidebarProps {
+  groups: NavGroup[];
+  headerContent?: React.ReactNode;
+  footerContent?: React.ReactNode;
+}
 
 export function PortalSidebar({
-  role,
-  userName,
-  userEmail,
-  navItems,
-  onLogout,
-  isOpen = true,
-  onClose,
-  homeHref,
+  groups,
+  headerContent,
+  footerContent,
 }: PortalSidebarProps) {
   const pathname = usePathname();
-  const homePath = homeHref || ROLE_HOME_PATHS[role] || '/';
+  const { user, logout } = useAuth();
+  const { role, displayName } = useRole();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    new Set()
+  );
 
-  const isActive = (href: string) => {
+  const toggleGroup = (groupId: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
+  };
+
+  const isActiveLink = (href: string) => {
     if (!pathname) return false;
-    if (href.endsWith('/dashboard')) {
-      return pathname === href;
+    if (href === '/dashboard') {
+      return pathname === '/dashboard';
     }
     return pathname.startsWith(href);
   };
 
-  // Close sidebar on route change (mobile)
-  useEffect(() => {
-    if (onClose) {
-      onClose();
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pathname]);
+  const renderNavItem = (item: NavItem) => {
+    const isActive = isActiveLink(item.href);
 
-  // Close on escape key
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && onClose) {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [onClose]);
+    return (
+      <Link
+        key={item.id}
+        href={item.href}
+        onClick={() => setIsMobileMenuOpen(false)}
+        className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+          isActive
+            ? 'bg-accent text-white shadow-sm'
+            : 'text-gray-700 hover:bg-gray-100'
+        }`}
+      >
+        <span className={isActive ? 'text-white' : 'text-gray-500'}>
+          {item.icon}
+        </span>
+        <span className="flex-1">{item.label}</span>
+        {item.badge !== undefined && item.badge > 0 && (
+          <span
+            className={`px-2 py-0.5 text-xs font-medium rounded-full ${
+              isActive ? 'bg-white/20 text-white' : 'bg-accent/10 text-accent'
+            }`}
+          >
+            {item.badge}
+          </span>
+        )}
+      </Link>
+    );
+  };
+
+  const renderNavGroup = (group: NavGroup) => {
+    const isCollapsed = collapsedGroups.has(group.id);
+
+    return (
+      <div key={group.id} className="mb-4">
+        {group.label && (
+          <button
+            onClick={() => group.collapsible && toggleGroup(group.id)}
+            className={`w-full flex items-center justify-between px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider ${
+              group.collapsible ? 'hover:text-gray-700 cursor-pointer' : ''
+            }`}
+          >
+            <span>{group.label}</span>
+            {group.collapsible && (
+              <span className="text-gray-400">
+                {isCollapsed ? (
+                  <ChevronRight className="w-4 h-4" />
+                ) : (
+                  <ChevronDown className="w-4 h-4" />
+                )}
+              </span>
+            )}
+          </button>
+        )}
+        {!isCollapsed && (
+          <div className="space-y-1">{group.items.map(renderNavItem)}</div>
+        )}
+      </div>
+    );
+  };
+
+  const sidebarContent = (
+    <>
+      {/* Logo */}
+      <div className="px-4 py-4 border-b border-gray-100">
+        <Logo href="/dashboard" size="md" />
+      </div>
+
+      {/* Optional Header Content */}
+      {headerContent && (
+        <div className="px-4 py-3 border-b border-gray-100">{headerContent}</div>
+      )}
+
+      {/* Navigation Groups */}
+      <nav className="flex-1 px-3 py-4 overflow-y-auto">
+        {groups.map(renderNavGroup)}
+      </nav>
+
+      {/* User Info & Logout */}
+      <div className="px-4 py-4 border-t border-gray-100">
+        <div className="flex items-center gap-3 mb-3">
+          <div className="w-10 h-10 bg-accent/10 rounded-full flex items-center justify-center">
+            <span className="text-accent font-semibold text-sm">
+              {user?.name?.charAt(0) || 'U'}
+            </span>
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-gray-900 truncate">
+              {user?.name || '사용자'}
+            </p>
+            <p className="text-xs text-gray-500 truncate">
+              {role ? ROLE_DISPLAY_NAMES[role] : ''}
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={logout}
+          className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+        >
+          <LogOut className="w-4 h-4" />
+          로그아웃
+        </button>
+      </div>
+
+      {/* Optional Footer Content */}
+      {footerContent && (
+        <div className="px-4 py-3 border-t border-gray-100">{footerContent}</div>
+      )}
+    </>
+  );
 
   return (
     <>
-      {/* Backdrop for mobile */}
-      {isOpen && onClose && (
+      {/* Desktop Sidebar */}
+      <aside className="hidden lg:flex lg:flex-col lg:w-64 lg:fixed lg:inset-y-0 bg-white border-r border-gray-200 z-30">
+        {sidebarContent}
+      </aside>
+
+      {/* Mobile Header */}
+      <header className="lg:hidden fixed top-0 left-0 right-0 h-16 bg-white border-b border-gray-200 z-40 px-4 flex items-center justify-between">
+        <Logo href="/dashboard" size="sm" />
+        <div className="flex items-center gap-2">
+          <NotificationDropdown />
+          <button
+            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg"
+            aria-label="메뉴"
+          >
+            {isMobileMenuOpen ? (
+              <X className="w-6 h-6" />
+            ) : (
+              <Menu className="w-6 h-6" />
+            )}
+          </button>
+        </div>
+      </header>
+
+      {/* Mobile Sidebar Overlay */}
+      {isMobileMenuOpen && (
         <div
-          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
-          onClick={onClose}
-          aria-hidden="true"
+          className="lg:hidden fixed inset-0 bg-black/50 z-40"
+          onClick={() => setIsMobileMenuOpen(false)}
         />
       )}
 
-      {/* Sidebar */}
+      {/* Mobile Sidebar */}
       <aside
-        className={`
-          flex flex-col w-64 h-screen bg-[var(--color-secondary)] text-white
-          fixed left-0 top-0 bottom-0 z-50
-          transform transition-transform duration-300 ease-in-out
-          lg:translate-x-0
-          ${isOpen ? 'translate-x-0' : '-translate-x-full'}
-        `}
+        className={`lg:hidden fixed top-0 right-0 bottom-0 w-72 bg-white z-50 transform transition-transform duration-300 ease-in-out flex flex-col ${
+          isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
       >
-        {/* Logo - T073: Home button links to role-specific dashboard */}
-        <div className="flex items-center justify-between h-16 px-6 border-b border-white/10">
-          <Link href={homePath} className="flex items-center gap-2">
-            <Logo size="sm" />
-            <span className="font-semibold text-lg">차곡 - 법률증거허브</span>
-          </Link>
-          {/* Close button for mobile */}
-          {onClose && (
-            <button
-              onClick={onClose}
-              className="lg:hidden p-2 rounded-lg hover:bg-white/10 transition-colors"
-              aria-label="메뉴 닫기"
-            >
-              <CloseIcon />
-            </button>
-          )}
+        <div className="flex items-center justify-between px-4 py-4 border-b border-gray-100">
+          <Logo href="/dashboard" size="sm" />
+          <button
+            onClick={() => setIsMobileMenuOpen(false)}
+            className="p-2 text-gray-600 hover:text-gray-900"
+            aria-label="닫기"
+          >
+            <X className="w-5 h-5" />
+          </button>
         </div>
-
-      {/* User Info */}
-      <div className="px-6 py-4 border-b border-white/10">
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-full bg-[var(--color-primary)] flex items-center justify-center font-semibold text-sm">
-            {userName.slice(0, 2).toUpperCase()}
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="font-medium truncate">{userName}</p>
-            <p className="text-sm text-white/60 truncate">{ROLE_DISPLAY_NAMES[role]}</p>
-          </div>
+        <nav className="flex-1 px-3 py-4 overflow-y-auto">
+          {groups.map(renderNavGroup)}
+        </nav>
+        <div className="px-4 py-4 border-t border-gray-100">
+          <button
+            onClick={() => {
+              logout();
+              setIsMobileMenuOpen(false);
+            }}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          >
+            <LogOut className="w-4 h-4" />
+            로그아웃
+          </button>
         </div>
-      </div>
-
-      {/* Navigation */}
-      <nav className="flex-1 px-3 py-4 space-y-1 overflow-y-auto">
-        {navItems.map((item) => {
-          const active = isActive(item.href);
-          return (
-            <Link
-              key={item.id}
-              href={item.href}
-              className={`
-                flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors
-                min-h-[44px]
-                ${active
-                  ? 'bg-[var(--color-primary)] text-white'
-                  : 'text-white/80 hover:bg-white/10 hover:text-white'
-                }
-              `}
-            >
-              {item.icon}
-              <span className="flex-1">{item.label}</span>
-              {item.badge !== undefined && item.badge > 0 && (
-                <span className="px-2 py-0.5 text-xs font-medium bg-[var(--color-error)] rounded-full">
-                  {item.badge > 99 ? '99+' : item.badge}
-                </span>
-              )}
-            </Link>
-          );
-        })}
-      </nav>
-
-      {/* Bottom Actions */}
-      <div className="px-3 py-4 border-t border-white/10 space-y-1">
-        <Link
-          href="/settings"
-          className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-white/80 hover:bg-white/10 hover:text-white transition-colors min-h-[44px]"
-        >
-          <SettingsIcon />
-          <span>설정</span>
-        </Link>
-        <button
-          onClick={onLogout}
-          className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-white/80 hover:bg-white/10 hover:text-white transition-colors w-full min-h-[44px]"
-        >
-          <LogoutIcon />
-          <span>로그아웃</span>
-        </button>
-      </div>
       </aside>
     </>
   );
 }
-
-// Hamburger menu icon for mobile header
-export const HamburgerIcon = () => (
-  <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-  </svg>
-);
 
 export default PortalSidebar;


### PR DESCRIPTION
## Summary
- PortalSidebar 컴포넌트를 NavGroup 기반으로 리팩토링
- 모든 포털 레이아웃(lawyer, client, detective)에 새로운 NavGroup 인터페이스 적용
- Lucide React 아이콘으로 통일

## Changes
- `PortalSidebar.tsx`: NavGroup 인터페이스로 계층적 네비게이션 지원
- `lawyer/layout.tsx`: 작업(작업, 관리) 그룹으로 구조화
- `client/layout.tsx`: NavGroup 인터페이스로 업데이트
- `detective/layout.tsx`: NavGroup 인터페이스로 업데이트

## Test Plan
- [x] Frontend build 성공 확인
- [ ] Staging에서 lawyer 포털 사이드바 동작 확인
- [ ] Staging에서 client 포털 사이드바 동작 확인
- [ ] Staging에서 detective 포털 사이드바 동작 확인