### PR TITLE
fix(backend): remove unused Optional import in gemini_client

### DIFF
--- a/backend/app/utils/gemini_client.py
+++ b/backend/app/utils/gemini_client.py
@@ -5,7 +5,7 @@ Gemini 2.0 Flash for fast, reliable legal document generation.
 """
 
 import logging
-from typing import List, Dict, Optional
+from typing import List, Dict
 import requests
 from app.core.config import settings
 


### PR DESCRIPTION
## Summary
- `gemini_client.py`의 미사용 `Optional` import 제거
- Ruff lint 에러 수정

## Test plan
- [ ] CI lint 통과 확인